### PR TITLE
change all uses of nid to Address, and remove nid type definition

### DIFF
--- a/Properties/InvCliqueTopology.v
+++ b/Properties/InvCliqueTopology.v
@@ -25,7 +25,7 @@ Definition saturated_chain w bc :=
   (* For any tree that induces bc *)
   forall bt, bc = btChain bt ->
     (* For any node in the world *)
-    forall (n : nid), holds n w
+    forall (n : Address), holds n w
     (* For any block in its local BlockTree *)
     (fun st => forall b, b ∈ blockTree st ->
     (* This block is not going to affect the blockchain out of bt *)
@@ -36,7 +36,7 @@ Definition valid_with_bc bt bc :=
    bc = btChain bt.
 
 Definition GSyncing_clique w :=
-  exists (bc : Blockchain) (bt : BlockTree) (n : nid),
+  exists (bc : Blockchain) (bt : BlockTree) (n : Address),
   [/\ holds n w (has_chain bc),
 
    (* The canonical chain is the largest in the network *)
@@ -164,7 +164,7 @@ case: dom_find=>//v'; rewrite F; case=>Z; subst v'=>->_.
 by rewrite updF eqxx updU eqxx.
 Qed.
 
-Lemma upd_nothing (n : nid) (st : State) (w : World) :
+Lemma upd_nothing (n : Address) (st : State) (w : World) :
   find n (localState w) = Some st -> upd n st (localState w) = (localState w).
 Proof. by apply find_upd_same. Qed.
 

--- a/Properties/InvMisc.v
+++ b/Properties/InvMisc.v
@@ -21,12 +21,12 @@ Unset Printing Implicit Defensive.
 Definition has_chain (bc : Blockchain) (st : State) : Prop :=
   btChain (blockTree st) == bc.
 
-Definition exists_and_holds (n : nid) (w : World) (cond : State -> Prop) :=
+Definition exists_and_holds (n : Address) (w : World) (cond : State -> Prop) :=
   exists (st : State),
     find n (localState w) = Some st /\ cond st.
 
 Definition chain_sync_agreement (w w' : World) :=
-  forall (n n' : nid) (bc bc' : Blockchain),
+  forall (n n' : Address) (bc bc' : Blockchain),
     holds n w (has_chain bc) ->
     reachable w w' ->
     holds n' w' (has_chain bc') ->
@@ -55,15 +55,15 @@ by rewrite/msg_block Msg.
 Qed.
 
 Definition largest_chain (w : World) (bc : Blockchain) :=
-   forall (n' : nid) (bc' : Blockchain),
+   forall (n' : Address) (bc' : Blockchain),
     holds n' w (fun st => has_chain bc' st -> bc >= bc').
 
 Definition GStable w :=
   inFlightMsgs w = [::] /\
-  exists (bc : Blockchain), forall (n : nid),
+  exists (bc : Blockchain), forall (n : Address),
       holds n w (has_chain bc).
 
-(* Definition all_available (n : nid) (w : World) : seq Block := *)
+(* Definition all_available (n : Address) (w : World) : seq Block := *)
 (*   let inv_hashes := *)
 (*     flatten [seq msg_hashes (msg p) | *)
 (*              p <- inFlightMsgs w & (dst p == n) && (msg_type (msg p) == MInv)] in *)
@@ -81,10 +81,10 @@ Definition GStable w :=
 * For simplicity, we assume all nodes are directly connected.
 * This could be changed to incorporate a more realistic broadcast setting.
 *)
-Definition available_rel (b : Block) (n : nid) (w : World) :=
+Definition available_rel (b : Block) (n : Address) (w : World) :=
   exists (p : Packet),
     p \in inFlightMsgs w /\
-    [\/ exists (peer : nid) (sh : seq Hash),
+    [\/ exists (peer : Address) (sh : seq Hash),
          msg p = InvMsg sh /\ dst p = n /\ hashB b \in sh |
        exists (hash : Hash),
          msg p = GetDataMsg hash /\ src p = n /\ hashB b = hash

--- a/Systems/Protocol.v
+++ b/Systems/Protocol.v
@@ -12,8 +12,7 @@ Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
 (* Implementation of PoS protocol as a STS *)
-Definition nid := nat.
-Definition peers_t := seq nid.
+Definition peers_t := seq Address.
 
 Inductive Message :=
   | NullMsg
@@ -139,7 +138,7 @@ Canonical Msg_eqType := Eval hnf in EqType Message Msg_eqMixin.
 End MsgEq.
 Export MsgEq.
 
-Record Packet := mkP {src: nid; dst: nid; msg: Message}.
+Record Packet := mkP {src: Address; dst: Address; msg: Message}.
 Definition NullPacket := mkP 0 0 NullMsg.
 
 Module PacketEq.
@@ -166,22 +165,22 @@ Definition emitZero : ToSend := [:: NullPacket].
 Definition emitOne (packet : Packet) : ToSend := [:: packet].
 Definition emitMany (packets : ToSend) := packets.
 
-Definition emitBroadcast (from : nid) (dst : seq nid) (msg : Message) :=
+Definition emitBroadcast (from : Address) (dst : seq Address) (msg : Message) :=
   [seq (mkP from to msg) | to <- dst].
 
 Record State :=
   Node {
-    id : nid;
+    id : Address;
     peers : peers_t;
     blockTree : BlockTree;
     txPool : TxPool;
   }.
 
-Definition Init (n : nid) : State :=
+Definition Init (n : Address) : State :=
   Node n [:: n] (#GenesisBlock \\-> GenesisBlock) [::].
-Lemma peers_uniq_init (n : nid) : uniq [::n]. Proof. done. Qed.
+Lemma peers_uniq_init (n : Address) : uniq [::n]. Proof. done. Qed.
 
-Definition procMsg (st: State) (from : nid) (msg: Message) (ts: Timestamp) :=
+Definition procMsg (st: State) (from : Address) (msg: Message) (ts: Timestamp) :=
     let: (Node n prs bt pool) := st in
     match msg with
     | ConnectMsg =>

--- a/Systems/States.v
+++ b/Systems/States.v
@@ -16,7 +16,7 @@ Section States.
 (* Number of nodes *)
 Variable N : nat.
 
-Definition StateMap := union_map [ordType of nid] State.
+Definition StateMap := union_map [ordType of Address] State.
 
 Fixpoint initState' n : StateMap :=
   if n is n'.+1 then (n \\-> Init n) \+ (initState' n') else Unit.


### PR DESCRIPTION
In lieu of a more fundamental solution (where `Address` is parameterized to be a more general type than `nat`), this pull request removes the `nid` type alias to make it clearer that nodes have an identifier of the same type as the first parameter of the `genProof` function.