### PR TITLE
remove redundant GetDataMsg code in procMsg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
-all: default doc
+all: default
 default: Makefile.coq
-	make -f Makefile.coq
+	$(MAKE) -f Makefile.coq
 
 clean: Makefile.coq
-	make -f Makefile.coq clean
+	$(MAKE) -f Makefile.coq clean
 	rm -f Makefile.coq
 
 Makefile.coq: _CoqProject
-	coq_makefile -f _CoqProject > Makefile.coq
+	coq_makefile -f _CoqProject -o Makefile.coq
 
-.PHONY: coq clean doc
+.PHONY: coq clean

--- a/Properties/InvCliqueTopology.v
+++ b/Properties/InvCliqueTopology.v
@@ -290,7 +290,7 @@ case: GSyncW=>can_bc [can_bt] [can_n] []
       by rewrite mem_undup mem_cat; apply/orP; left.
       by case: ifP=>_;
          [rewrite mem_undup|rewrite -cat1s mem_cat mem_undup; apply/orP; right].
-    * case: ifP=>//_; first by case: ifP => //=.
+    * case: ifP=>//_; first by case: ifP; move/eqP => //= H_eq; case ohead.
       move/eqP => H_neq.
       move => F'; clear H1; move: (HCliq n' _ F')=>H1.
       move=>z; specialize (H1 z); specialize (H2 z).
@@ -328,11 +328,9 @@ case: GSyncW=>can_bc [can_bt] [can_n] []
       case: ifP=>//=; move=>/eqP En'.
       - rewrite/get_block. (* blockTree wrt. the state of (dst p) in w *)
         case X: (find hash blockTree0)=>[b|].
-        -- case: ifP => //=.
-           move/eqP => H_n'.
-           rewrite -E;
-             suff BIn: (b ∈ can_bt) by apply (btExtend_withDup_noEffect BIn).
-             by move: (HExt _ _ F)=>/= ->; move: (find_some X)=>Dom;
+        -- case: ifP => //=; move/eqP => H_n'.
+           rewrite -E; suff BIn: (b ∈ can_bt) by apply (btExtend_withDup_noEffect BIn).
+           by move: (HExt _ _ F)=>/= ->; move: (find_some X)=>Dom;
               move: (c4 _ _ F hash b X)=>H; rewrite H in Dom;
               rewrite/btHasBlock;
               move: (btExtend_fold_preserve (blocksFor (dst p) w) (c3 _ _ F) Dom).
@@ -340,14 +338,14 @@ case: GSyncW=>can_bc [can_bt] [can_n] []
            case: ifP => //=.
            move/eqP => H_n'.
            by move: (btExtend_withDup_noEffect hG)=><-.
-      - case: ifP => //=.
-        move/eqP => H_n'.
-        rewrite -E.
-        suff BIn: (GenesisBlock ∈ can_bt) by apply (btExtend_withDup_noEffect BIn).
-        move: C => [H_v H_v'] => H_ib.
-        rewrite /has_init_block in H_ib.
-        rewrite /btHasBlock.
-        by move: (find_some H_ib).
+      - by case ohead => [tx|] //=;
+         case: ifP => //=; move/eqP => H_eq;
+         rewrite -E;
+         (suff BIn: (GenesisBlock ∈ can_bt) by apply (btExtend_withDup_noEffect BIn));
+         move: C => [H_v H_v'] => H_ib;
+         rewrite /has_init_block in H_ib;
+         rewrite /btHasBlock;
+         move: (find_some H_ib).
     * move/eqP=>Eq [Eq']; subst n' stPm.
       rewrite/blocksFor/inFlightMsgs; simplw w=>_ ->; rewrite/procMsg.
       move: (P); rewrite [procMsg _ _ _ _] surjective_pairing; case=>Z1 Z2.
@@ -386,12 +384,13 @@ case: GSyncW=>can_bc [can_bt] [can_n] []
       destruct st; rewrite -Z2 /procMsg Msg /=; case: ifP=>/=X.
       * by case: ifP=>/=?;
           do? [rewrite/has_init_block /= in G';
-             move: (btExtend_withDup_noEffect (find_some G'))=><-];
-          move: (HExt _ _ F); rewrite/blocksFor=>-> /=;
-          do [rewrite Z1 in H'; rewrite (rem_non_block w V')//;
+              move: (btExtend_withDup_noEffect (find_some G'))=><-];
+           move: (HExt _ _ F); rewrite/blocksFor=>-> /=;
+           do [rewrite Z1 in H'; rewrite (rem_non_block w V')//;
             last by case: (msg p) Msg];
-          rewrite -Z1 Msg/=; case: ifP => //=; move/eqP => H_neq;
-          case: ifP.
+           rewrite -Z1 Msg/=; case: ifP => //=; move/eqP => H_neq;
+           case: ifP; move/eqP => H_neq' //=;
+           case ohead.
       * case: ifP => H_neq //=.
         - case:ifP=> //= Y; first by move/eqP:Y=>Y; rewrite Y eq_sym (c2 _ _ F) in X.
           rewrite Z1 in H'.
@@ -400,14 +399,15 @@ case: GSyncW=>can_bc [can_bt] [can_n] []
           case: ifP; move/eqP => H_eq; first by move/eqP: X.
           case: ifP => H_eq' //=; last by move/eqP: H_eq' => H_eq'; move/eqP: H_neq => H_neq.
           exact: (HExt _ _ F).
-        - move/eqP: H_neq => H_neq.
-          by case:ifP=> //=; move/eqP => H_eq;
+        - move/eqP: H_neq => H_neq //=.
+          by case ohead => [tx|] //=;
+          case:ifP=> //=; move/eqP => H_eq;
            do? [rewrite/has_init_block /= in G';
            move: (btExtend_withDup_noEffect (find_some G'))=><-];
            move: (HExt _ _ F); rewrite/blocksFor=>-> /=;
            do [rewrite Z1 in H'; rewrite (rem_non_block w V')//; last by case: (msg p) Msg];
            rewrite -Z1 Msg/=; case: ifP => //=;
-           case: ifP.
+           case: ifP; move/eqP => H_neq' //=; case ohead.
 
 (* Internal *)
 move=>proc t st [c1 c2 c3 c4 c5 c6] Al F.

--- a/Properties/InvCliqueTopology.v
+++ b/Properties/InvCliqueTopology.v
@@ -290,11 +290,11 @@ case: GSyncW=>can_bc [can_bt] [can_n] []
       by rewrite mem_undup mem_cat; apply/orP; left.
       by case: ifP=>_;
          [rewrite mem_undup|rewrite -cat1s mem_cat mem_undup; apply/orP; right].
-    * case: ifP=>//_.
-      by move=>_ F'; clear H1; move: (HCliq n' _ F')=>H1;
-         move=>z; specialize (H1 z); specialize (H2 z);
-         rewrite H2 in H1=>H3; specialize (H1 H3).
-
+    * case: ifP=>//_; first by case: ifP => //=.
+      move/eqP => H_neq.
+      move => F'; clear H1; move: (HCliq n' _ F')=>H1.
+      move=>z; specialize (H1 z); specialize (H2 z).
+      by rewrite H2 in H1=>H3; specialize (H1 H3).
   (* applying conserved *)
   + move=>n' st'; rewrite findU c1 /=; case: ifP; last first.
     * move=>NDst F'; move: (HExt _ st' F').
@@ -324,17 +324,30 @@ case: GSyncW=>can_bc [can_bt] [can_n] []
       rewrite/procMsg Msg /=; case: ifP=>/=;
       first by case: ifP=>//=;
         by move: (find_some hIB)=>hG; move: (btExtend_withDup_noEffect hG)=><-.
-      move=>Src; case: ifP=>//=; move=>/eqP En'; subst n'.
-      rewrite/get_block. (* blockTree wrt. the state of (dst p) in w *)
-      case X: (find hash blockTree0)=>[b|];
-      last by move: (find_some hIB)=>hG;
-              move: (btExtend_withDup_noEffect hG)=><-.
-      rewrite -E;
-      suff BIn: (b ∈ can_bt) by apply (btExtend_withDup_noEffect BIn).
-      by move: (HExt _ _ F)=>/= ->; move: (find_some X)=>Dom;
-         move: (c4 _ _ F hash b X)=>H; rewrite H in Dom;
-         rewrite/btHasBlock;
-         move: (btExtend_fold_preserve (blocksFor (dst p) w) (c3 _ _ F) Dom).
+      move/eqP => H_neq.
+      case: ifP=>//=; move=>/eqP En'.
+      - rewrite/get_block. (* blockTree wrt. the state of (dst p) in w *)
+        case X: (find hash blockTree0)=>[b|].
+        -- case: ifP => //=.
+           move/eqP => H_n'.
+           rewrite -E;
+             suff BIn: (b ∈ can_bt) by apply (btExtend_withDup_noEffect BIn).
+             by move: (HExt _ _ F)=>/= ->; move: (find_some X)=>Dom;
+              move: (c4 _ _ F hash b X)=>H; rewrite H in Dom;
+              rewrite/btHasBlock;
+              move: (btExtend_fold_preserve (blocksFor (dst p) w) (c3 _ _ F) Dom).
+        -- move: (find_some hIB)=>hG.
+           case: ifP => //=.
+           move/eqP => H_n'.
+           by move: (btExtend_withDup_noEffect hG)=><-.
+      - case: ifP => //=.
+        move/eqP => H_n'.
+        rewrite -E.
+        suff BIn: (GenesisBlock ∈ can_bt) by apply (btExtend_withDup_noEffect BIn).
+        move: C => [H_v H_v'] => H_ib.
+        rewrite /has_init_block in H_ib.
+        rewrite /btHasBlock.
+        by move: (find_some H_ib).
     * move/eqP=>Eq [Eq']; subst n' stPm.
       rewrite/blocksFor/inFlightMsgs; simplw w=>_ ->; rewrite/procMsg.
       move: (P); rewrite [procMsg _ _ _ _] surjective_pairing; case=>Z1 Z2.
@@ -372,16 +385,29 @@ case: GSyncW=>can_bc [can_bt] [can_n] []
       (* GetDataMsg *)
       destruct st; rewrite -Z2 /procMsg Msg /=; case: ifP=>/=X.
       * by case: ifP=>/=?;
-        do? [rewrite/has_init_block /= in G';
+          do? [rewrite/has_init_block /= in G';
              move: (btExtend_withDup_noEffect (find_some G'))=><-];
-        move: (HExt _ _ F); rewrite/blocksFor=>-> /=;
-        do [rewrite Z1 in H'; rewrite (rem_non_block w V')//;
+          move: (HExt _ _ F); rewrite/blocksFor=>-> /=;
+          do [rewrite Z1 in H'; rewrite (rem_non_block w V')//;
             last by case: (msg p) Msg];
-           by rewrite -Z1 Msg/=; case: ifP.
-        rewrite Z1 in H'; case:ifP=>Y; first by move/eqP:Y=>Y;
-        rewrite Y eq_sym (c2 _ _ F) in X.
-      rewrite (rem_non_block w V')//; last by case: (msg p) Msg.
-      by rewrite -Z1 Msg/=; case: ifP=>_/=; apply: (HExt _ _ F).
+          rewrite -Z1 Msg/=; case: ifP => //=; move/eqP => H_neq;
+          case: ifP.
+      * case: ifP => H_neq //=.
+        - case:ifP=> //= Y; first by move/eqP:Y=>Y; rewrite Y eq_sym (c2 _ _ F) in X.
+          rewrite Z1 in H'.
+          rewrite (rem_non_block w V')//; last by case: (msg p) Msg.
+          rewrite -Z1 Msg/=.
+          case: ifP; move/eqP => H_eq; first by move/eqP: X.
+          case: ifP => H_eq' //=; last by move/eqP: H_eq' => H_eq'; move/eqP: H_neq => H_neq.
+          exact: (HExt _ _ F).
+        - move/eqP: H_neq => H_neq.
+          by case:ifP=> //=; move/eqP => H_eq;
+           do? [rewrite/has_init_block /= in G';
+           move: (btExtend_withDup_noEffect (find_some G'))=><-];
+           move: (HExt _ _ F); rewrite/blocksFor=>-> /=;
+           do [rewrite Z1 in H'; rewrite (rem_non_block w V')//; last by case: (msg p) Msg];
+           rewrite -Z1 Msg/=; case: ifP => //=;
+           case: ifP.
 
 (* Internal *)
 move=>proc t st [c1 c2 c3 c4 c5 c6] Al F.

--- a/Systems/Protocol.v
+++ b/Systems/Protocol.v
@@ -215,7 +215,7 @@ Definition procMsg (st: State) (from : Address) (msg: Message) (ts: Timestamp) :
     | GetDataMsg h =>
       (* Do not respond to yourself *)
       if from == n then pair st emitZero else
-      let: matchingBlocks := [:: get_block bt h] in
+      let: matchingBlocks := [seq b <- [:: get_block bt h] | b != GenesisBlock] in
       match ohead matchingBlocks with
       | Some(b) => pair (Node n prs bt pool) (emitOne(mkP n from (BlockMsg b)))
       | None => pair st emitZero
@@ -258,7 +258,8 @@ Definition procInt (st : State) (tr : InternalTransition) (ts : Timestamp) :=
 Lemma procMsg_id_constant (s1 : State) from (m : Message) (ts : Timestamp) :
     id s1 = id (procMsg s1 from m ts).1.
 Proof.
-by case: s1 from m ts=>n1 p1 b1 t1 from []=>//=??; case:ifP. 
+case: s1 from m ts=>n1 p1 b1 t1 from []=>//=??; case:ifP => //=.
+by move/eqP => H_neq; case: ifP.
 Qed.
 
 Lemma procInt_id_constant : forall (s1 : State) (t : InternalTransition) (ts : Timestamp),
@@ -275,7 +276,8 @@ Proof.
 move=> s1 from  m ts.
 case Msg: m=>[|||b|||];
 destruct s1; rewrite/procMsg/=; do?by [|move: (btExtendV blockTree0 b)=><-].
-by case:ifP.
+case:ifP => //=.
+by move/eqP => H_neq; case: ifP.
 Qed.
 
 Lemma procInt_valid :
@@ -297,8 +299,9 @@ Lemma procMsg_validH :
 Proof.
 move=> s1 from  m ts.
 case Msg: m=>[|||b|||];
-destruct s1; rewrite/procMsg/=; do? by []; do? by case: ifP.
-by move=>v vh; apply btExtendH.
+destruct s1; rewrite/procMsg/=; do? by []; do? by case: ifP => //=.
+- by move=>v vh; apply btExtendH.
+- by move=>v vh; case: ifP => //=; move/eqP => H_neq; case: ifP.
 Qed.
 
 Lemma procInt_validH :
@@ -323,7 +326,8 @@ Proof.
 move=> s1 from  m ts.
 case Msg: m=>[|||b|||];
 destruct s1; rewrite/procMsg/=; do? by []; do? by case:ifP.
-by apply btExtendIB.
+- by apply btExtendIB.
+- by move=>v vh; case: ifP => //=; move/eqP => H_neq; case: ifP.
 Qed.
 
 Lemma procInt_has_init_block :
@@ -350,7 +354,8 @@ case=> n1 p1 b1 t1 from; case; do? by []; simpl.
 - move=>_ U; case: ifP=>X; rewrite //= ?undup_uniq//=. 
   rewrite andbC/=; apply/negbT/negP; rewrite mem_undup=>Z.
   by rewrite Z in X.
-by move=>s _ U; case: ifP.
+- move=>s _ U; case: ifP => //=.
+  by move/eqP => H_eq; case: ifP.
 Qed.
 
 Ltac local_bc_no_change s1 hbc hbc' :=
@@ -367,7 +372,8 @@ move=>s1 from m ts neq.
 case: m neq=>[|prs||b|t|sh|h] neq;
   do? by[rewrite/procMsg; destruct s1=>/=].
 - by specialize (neq b); contradict neq; rewrite eqxx.
-by rewrite/procMsg/=; case: s1=>????/=; case:ifP.
+- rewrite/procMsg/=; case: s1=>????/=; case:ifP => //=.
+  by move/eqP => H_neq; case: ifP.
 Qed.
 
 Lemma procMsg_non_block_nc_btChain :

--- a/Systems/Protocol.v
+++ b/Systems/Protocol.v
@@ -216,18 +216,10 @@ Definition procMsg (st: State) (from : Address) (msg: Message) (ts: Timestamp) :
       (* Do not respond to yourself *)
       if from == n then pair st emitZero else
       let: matchingBlocks := [:: get_block bt h] in
-      let: matchingTxs := [seq t <- pool | (hashT t) == h] in
       match ohead matchingBlocks with
-      | Some(b) =>
-        pair (Node n prs bt pool) (emitOne(mkP n from (BlockMsg b)))
-      | _ =>
-        match ohead matchingTxs with
-        | Some (tx) =>
-          pair (Node n prs bt pool) (emitOne(mkP n from (TxMsg tx)))
-        | _ => pair st emitZero
-        end
+      | Some(b) => pair (Node n prs bt pool) (emitOne(mkP n from (BlockMsg b)))
+      | None => pair st emitZero
       end
-
     | NullMsg => pair st emitZero
     end.
 


### PR DESCRIPTION
This pull request both proposes a fix and raises a general issue (question).

Consider that the assignment `let: matchingBlocks := [:: get_block bt h] in` in `Protocol.v` always leaves `matchingBlocks` as a non-empty list. This means that pattern matching on `ohead matchingBlocks` will always take the `Some(b)` branch, no matter what. In turn, this implies that all the code related to `matchingTxs` is redundant.

As this pull request shows, all the theorems still hold with `matchingTxs` code excised. But is this really the intention, i.e., does it capture real-world blockchain protocol behavior? I'd be interested in any ideas or pointers there.