### PR TITLE
use arbitrary finType for Address instead of nat

### DIFF
--- a/Properties/InvCliqueTopology.v
+++ b/Properties/InvCliqueTopology.v
@@ -1,5 +1,5 @@
 From mathcomp.ssreflect
-Require Import ssreflect ssrbool ssrnat eqtype ssrfun seq.
+Require Import ssreflect ssrbool ssrnat eqtype ssrfun seq fintype.
 From mathcomp
 Require Import path.
 Require Import Eqdep.

--- a/Properties/InvMisc.v
+++ b/Properties/InvMisc.v
@@ -1,5 +1,5 @@
 From mathcomp.ssreflect
-Require Import ssreflect ssrbool ssrnat eqtype ssrfun seq.
+Require Import ssreflect ssrbool ssrnat eqtype ssrfun seq fintype.
 From mathcomp
 Require Import path.
 Require Import Eqdep.

--- a/Structures/Forests.v
+++ b/Structures/Forests.v
@@ -1,5 +1,5 @@
 From mathcomp.ssreflect
-Require Import ssreflect ssrbool ssrnat eqtype ssrfun seq.
+Require Import ssreflect ssrbool ssrnat eqtype ssrfun seq fintype.
 From mathcomp
 Require Import path.
 Require Import Eqdep.
@@ -13,7 +13,6 @@ Unset Printing Implicit Defensive.
 
 (* A fomalization of a block forests *)
 
-Definition Address := nat.
 Definition Timestamp := nat.
 Definition Hash := [ordType of nat].
 
@@ -23,6 +22,8 @@ Definition Hash := [ordType of nat].
 
 Parameter VProof : eqType.
 Parameter Transaction : eqType.
+Parameter Address : finType.
+Parameter NullAddress : Address.
 
 Definition block := @Block Transaction VProof.
 Parameter GenesisBlock : block.

--- a/Systems/Network.v
+++ b/Systems/Network.v
@@ -1,5 +1,5 @@
 From mathcomp.ssreflect
-Require Import ssreflect ssrbool ssrnat eqtype ssrfun seq.
+Require Import ssreflect ssrbool ssrnat eqtype ssrfun seq fintype.
 From mathcomp
 Require Import path.
 Require Import Eqdep.
@@ -11,7 +11,6 @@ Require Import Protocol Chains Forests States.
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
-
 
 Section Semantics.
 
@@ -84,10 +83,9 @@ Definition reachable (w w' : World) :=
 (* properties of the world, such as block-trees of the majority of
 involved peers are not _too different_. *)
 
-Variable N : nat.
+Definition initWorld := mkW initState [::] [::].
 
-Definition initWorld := mkW (initState N) [::] [::].
-
+(*
 Ltac InitState_induction :=
 move=>n st; elim: N=>//=[|n' Hi];
 do? [by move/find_some; rewrite dom0 inE];
@@ -99,6 +97,7 @@ do? [
   ]
 ];
 case: ifP=>//; rewrite um_domPt inE=>/eqP<-.
+*)
 
 Ltac Coh_step_case n d H F :=
   case B: (n == d);
@@ -108,15 +107,213 @@ Ltac Coh_step_case n d H F :=
 
 Lemma Coh_init : Coh initWorld.
 Proof.
-rewrite /initWorld/initState/localState/=; split;
-do? InitState_induction; do? [rewrite um_findPt; case=><-].
-- by apply: valid_initState.
-- by rewrite/Init/id.
-- by rewrite /Init/blockTree gen_validPt.
-- by rewrite/Init/validH/blockTree=>h b H;
-     move: (um_findPt_inv H); elim=>->->.
-- by rewrite/Init/has_init_block/blockTree um_findPt.
-- by rewrite/Init/peers.
+rewrite /initWorld/initState/localState/=; split.
+- apply: valid_initState'.
+  exact: enum_uniq.
+- move => n.
+  have H_in: n \in enum Address by rewrite mem_enum.
+  have H_un: uniq (enum Address) by apply enum_uniq.
+  move: H_in H_un.
+  elim: (enum Address) => //=.
+  move => a s IH.
+  rewrite inE.
+  move/orP.
+  case.
+  * move/eqP => H_eq /=.
+    rewrite H_eq.
+    move/andP => [H_in H_u].
+    rewrite /holds /= => st.
+    rewrite gen_findPtUn.
+    + by case => H_i; rewrite -H_i.
+    + case: validUn; rewrite ?um_validPt ?valid_initState'//.
+      move=>k; rewrite um_domPt !inE=>/eqP <-.
+      rewrite dom_initState' //.
+      by move/negP: H_in.
+  * move => H_in.
+    move/andP => [H_ni H_u].
+    have H_neq: n <> a.
+      move => H_eq.
+      rewrite -H_eq in H_ni.
+      by move/negP: H_ni.
+    move: H_in.
+    move/IH {IH} => IH.
+    have H_u' := H_u.
+    move: H_u'.
+    move/IH {IH}.
+    rewrite /holds /= => IH st.
+    rewrite findUnL.
+    + case: ifP; last by move => H_in H_f; exact: IH.
+      rewrite um_domPt inE.
+      rewrite eq_sym.
+      by move/eqP.
+    + case: validUn; rewrite ?um_validPt ?valid_initState'//.
+      move=>k; rewrite um_domPt !inE=>/eqP <-.
+      rewrite dom_initState' //.
+      by move/negP: H_ni.
+- move => n.
+  have H_in: n \in enum Address by rewrite mem_enum.
+  have H_un: uniq (enum Address) by apply enum_uniq.
+  move: H_in H_un.
+  elim: (enum Address) => //=.
+  move => a s IH.
+  rewrite inE.
+  move/orP.
+  case.
+  * move/eqP => H_eq /=.
+    rewrite H_eq.
+    move/andP => [H_in H_u].
+    rewrite /holds /= => st.
+    rewrite gen_findPtUn.
+    + case => H_i; rewrite -H_i.
+      by rewrite /blockTree /= um_validPt.
+    + case: validUn; rewrite ?um_validPt ?valid_initState'//.
+      move=>k; rewrite um_domPt !inE=>/eqP <-.
+      rewrite dom_initState' //.
+      by move/negP: H_in.
+  * move => H_in.
+    move/andP => [H_ni H_u].
+    have H_neq: n <> a.
+      move => H_eq.
+      rewrite -H_eq in H_ni.
+      by move/negP: H_ni.
+    move: H_in.
+    move/IH {IH} => IH.
+    have H_u' := H_u.
+    move: H_u'.
+    move/IH {IH}.
+    rewrite /holds /= => IH st.
+    rewrite findUnL.
+    + case: ifP; last by move => H_in H_f; exact: IH.
+      rewrite um_domPt inE.
+      rewrite eq_sym.
+      by move/eqP.
+    + case: validUn; rewrite ?um_validPt ?valid_initState'//.
+      move=>k; rewrite um_domPt !inE=>/eqP <-.
+      rewrite dom_initState' //.
+      by move/negP: H_ni.
+- move => n.
+  have H_in: n \in enum Address by rewrite mem_enum.
+  have H_un: uniq (enum Address) by apply enum_uniq.
+  move: H_in H_un.
+  elim: (enum Address) => //=.
+  move => a s IH.
+  rewrite inE.
+  move/orP.
+  case.
+  * move/eqP => H_eq /=.
+    rewrite H_eq.
+    move/andP => [H_in H_u].
+    rewrite /holds /= => st.
+    rewrite gen_findPtUn.
+    + case => H_i; rewrite -H_i.
+      rewrite/validH/blockTree /= => h b H.
+      by move: (um_findPt_inv H); elim=>->->.
+    + case: validUn; rewrite ?um_validPt ?valid_initState'//.
+      move=>k; rewrite um_domPt !inE=>/eqP <-.
+      rewrite dom_initState' //.
+      by move/negP: H_in.
+  * move => H_in.
+    move/andP => [H_ni H_u].
+    have H_neq: n <> a.
+      move => H_eq.
+      rewrite -H_eq in H_ni.
+      by move/negP: H_ni.
+    move: H_in.
+    move/IH {IH} => IH.
+    have H_u' := H_u.
+    move: H_u'.
+    move/IH {IH}.
+    rewrite /holds /= => IH st.
+    rewrite findUnL.
+    + case: ifP; last by move => H_in H_f; exact: IH.
+      rewrite um_domPt inE.
+      rewrite eq_sym.
+      by move/eqP.
+    + case: validUn; rewrite ?um_validPt ?valid_initState'//.
+      move=>k; rewrite um_domPt !inE=>/eqP <-.
+      rewrite dom_initState' //.
+      by move/negP: H_ni.
+- move => n.
+  have H_in: n \in enum Address by rewrite mem_enum.
+  have H_un: uniq (enum Address) by apply enum_uniq.
+  move: H_in H_un.
+  elim: (enum Address) => //=.
+  move => a s IH.
+  rewrite inE.
+  move/orP.
+  case.
+  * move/eqP => H_eq /=.
+    rewrite H_eq.
+    move/andP => [H_in H_u].
+    rewrite /holds /= => st.
+    rewrite gen_findPtUn.
+    + case => H_i; rewrite -H_i.
+      by rewrite/has_init_block/blockTree um_findPt.
+    + case: validUn; rewrite ?um_validPt ?valid_initState'//.
+      move=>k; rewrite um_domPt !inE=>/eqP <-.
+      rewrite dom_initState' //.
+      by move/negP: H_in.
+  * move => H_in.
+    move/andP => [H_ni H_u].
+    have H_neq: n <> a.
+      move => H_eq.
+      rewrite -H_eq in H_ni.
+      by move/negP: H_ni.
+    move: H_in.
+    move/IH {IH} => IH.
+    have H_u' := H_u.
+    move: H_u'.
+    move/IH {IH}.
+    rewrite /holds /= => IH st.
+    rewrite findUnL.
+    + case: ifP; last by move => H_in H_f; exact: IH.
+      rewrite um_domPt inE.
+      rewrite eq_sym.
+      by move/eqP.
+    + case: validUn; rewrite ?um_validPt ?valid_initState'//.
+      move=>k; rewrite um_domPt !inE=>/eqP <-.
+      rewrite dom_initState' //.
+      by move/negP: H_ni.
+- move => n.
+  have H_in: n \in enum Address by rewrite mem_enum.
+  have H_un: uniq (enum Address) by apply enum_uniq.
+  move: H_in H_un.
+  elim: (enum Address) => //=.
+  move => a s IH.
+  rewrite inE.
+  move/orP.
+  case.
+  * move/eqP => H_eq /=.
+    rewrite H_eq.
+    move/andP => [H_in H_u].
+    rewrite /holds /= => st.
+    rewrite gen_findPtUn.
+    + by case => H_i; rewrite -H_i.
+    + case: validUn; rewrite ?um_validPt ?valid_initState'//.
+      move=>k; rewrite um_domPt !inE=>/eqP <-.
+      rewrite dom_initState' //.
+      by move/negP: H_in.
+  * move => H_in.
+    move/andP => [H_ni H_u].
+    have H_neq: n <> a.
+      move => H_eq.
+      rewrite -H_eq in H_ni.
+      by move/negP: H_ni.
+    move: H_in.
+    move/IH {IH} => IH.
+    have H_u' := H_u.
+    move: H_u'.
+    move/IH {IH}.
+    rewrite /holds /= => IH st.
+    rewrite findUnL.
+    + case: ifP; last by move => H_in H_f; exact: IH.
+      rewrite um_domPt inE.
+      rewrite eq_sym.
+      by move/eqP.
+    + case: validUn; rewrite ?um_validPt ?valid_initState'//.
+      move=>k; rewrite um_domPt !inE=>/eqP <-.
+      rewrite dom_initState' //.
+      by move/negP: H_ni.
 Qed.
 
 Lemma Coh_step w w' q:

--- a/Systems/Network.v
+++ b/Systems/Network.v
@@ -12,9 +12,6 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Section Semantics.
-
-(* Number of nodes *)
 Definition PacketSoup := seq Packet.
 
 Record World :=
@@ -105,215 +102,47 @@ Ltac Coh_step_case n d H F :=
     case: ifP; last done
   ]; move=>_ [] <-.
 
+Lemma holds_Init_state : forall (P : State -> Prop) n, P (Init n) ->
+  holds n {| localState := initState' (enum Address); inFlightMsgs := [::]; consumedMsgs := [::] |} (fun st : State => P st).
+Proof.
+move => P n H_P.
+have H_in: n \in enum Address by rewrite mem_enum.
+have H_un: uniq (enum Address) by apply enum_uniq.
+move: H_in H_un; elim: (enum Address) => //=.
+move => a s IH; rewrite inE; move/orP; case.
+* move/eqP => H_eq /=.
+  rewrite H_eq; move/andP => [H_in H_u].
+  rewrite /holds /= => st; rewrite gen_findPtUn; first by case => H_i; rewrite -H_i -H_eq.
+  by case: validUn; rewrite ?um_validPt ?valid_initState'//;
+   move=>k; rewrite um_domPt !inE=>/eqP <-;
+   rewrite dom_initState' //; move/negP: H_in.
+* move => H_in; move/andP => [H_ni H_u].
+  have H_neq: n <> a by move => H_eq; rewrite -H_eq in H_ni; move/negP: H_ni.
+  move: H_in; move/IH {IH} => IH.
+  have H_u' := H_u.
+  move: H_u'; move/IH {IH}.
+  rewrite /holds /= => IH st; rewrite findUnL.
+  + case: ifP; last by move => H_in H_f; exact: IH.
+    by rewrite um_domPt inE eq_sym; move/eqP.
+  + by case: validUn; rewrite ?um_validPt ?valid_initState'//;
+     move=>k; rewrite um_domPt !inE=>/eqP <-;
+     rewrite dom_initState' //; move/negP: H_ni.
+Qed.
+
 Lemma Coh_init : Coh initWorld.
 Proof.
 rewrite /initWorld/initState/localState/=; split.
 - apply: valid_initState'.
   exact: enum_uniq.
-- move => n.
-  have H_in: n \in enum Address by rewrite mem_enum.
-  have H_un: uniq (enum Address) by apply enum_uniq.
-  move: H_in H_un.
-  elim: (enum Address) => //=.
-  move => a s IH.
-  rewrite inE.
-  move/orP.
-  case.
-  * move/eqP => H_eq /=.
-    rewrite H_eq.
-    move/andP => [H_in H_u].
-    rewrite /holds /= => st.
-    rewrite gen_findPtUn.
-    + by case => H_i; rewrite -H_i.
-    + case: validUn; rewrite ?um_validPt ?valid_initState'//.
-      move=>k; rewrite um_domPt !inE=>/eqP <-.
-      rewrite dom_initState' //.
-      by move/negP: H_in.
-  * move => H_in.
-    move/andP => [H_ni H_u].
-    have H_neq: n <> a.
-      move => H_eq.
-      rewrite -H_eq in H_ni.
-      by move/negP: H_ni.
-    move: H_in.
-    move/IH {IH} => IH.
-    have H_u' := H_u.
-    move: H_u'.
-    move/IH {IH}.
-    rewrite /holds /= => IH st.
-    rewrite findUnL.
-    + case: ifP; last by move => H_in H_f; exact: IH.
-      rewrite um_domPt inE.
-      rewrite eq_sym.
-      by move/eqP.
-    + case: validUn; rewrite ?um_validPt ?valid_initState'//.
-      move=>k; rewrite um_domPt !inE=>/eqP <-.
-      rewrite dom_initState' //.
-      by move/negP: H_ni.
-- move => n.
-  have H_in: n \in enum Address by rewrite mem_enum.
-  have H_un: uniq (enum Address) by apply enum_uniq.
-  move: H_in H_un.
-  elim: (enum Address) => //=.
-  move => a s IH.
-  rewrite inE.
-  move/orP.
-  case.
-  * move/eqP => H_eq /=.
-    rewrite H_eq.
-    move/andP => [H_in H_u].
-    rewrite /holds /= => st.
-    rewrite gen_findPtUn.
-    + case => H_i; rewrite -H_i.
-      by rewrite /blockTree /= um_validPt.
-    + case: validUn; rewrite ?um_validPt ?valid_initState'//.
-      move=>k; rewrite um_domPt !inE=>/eqP <-.
-      rewrite dom_initState' //.
-      by move/negP: H_in.
-  * move => H_in.
-    move/andP => [H_ni H_u].
-    have H_neq: n <> a.
-      move => H_eq.
-      rewrite -H_eq in H_ni.
-      by move/negP: H_ni.
-    move: H_in.
-    move/IH {IH} => IH.
-    have H_u' := H_u.
-    move: H_u'.
-    move/IH {IH}.
-    rewrite /holds /= => IH st.
-    rewrite findUnL.
-    + case: ifP; last by move => H_in H_f; exact: IH.
-      rewrite um_domPt inE.
-      rewrite eq_sym.
-      by move/eqP.
-    + case: validUn; rewrite ?um_validPt ?valid_initState'//.
-      move=>k; rewrite um_domPt !inE=>/eqP <-.
-      rewrite dom_initState' //.
-      by move/negP: H_ni.
-- move => n.
-  have H_in: n \in enum Address by rewrite mem_enum.
-  have H_un: uniq (enum Address) by apply enum_uniq.
-  move: H_in H_un.
-  elim: (enum Address) => //=.
-  move => a s IH.
-  rewrite inE.
-  move/orP.
-  case.
-  * move/eqP => H_eq /=.
-    rewrite H_eq.
-    move/andP => [H_in H_u].
-    rewrite /holds /= => st.
-    rewrite gen_findPtUn.
-    + case => H_i; rewrite -H_i.
-      rewrite/validH/blockTree /= => h b H.
-      by move: (um_findPt_inv H); elim=>->->.
-    + case: validUn; rewrite ?um_validPt ?valid_initState'//.
-      move=>k; rewrite um_domPt !inE=>/eqP <-.
-      rewrite dom_initState' //.
-      by move/negP: H_in.
-  * move => H_in.
-    move/andP => [H_ni H_u].
-    have H_neq: n <> a.
-      move => H_eq.
-      rewrite -H_eq in H_ni.
-      by move/negP: H_ni.
-    move: H_in.
-    move/IH {IH} => IH.
-    have H_u' := H_u.
-    move: H_u'.
-    move/IH {IH}.
-    rewrite /holds /= => IH st.
-    rewrite findUnL.
-    + case: ifP; last by move => H_in H_f; exact: IH.
-      rewrite um_domPt inE.
-      rewrite eq_sym.
-      by move/eqP.
-    + case: validUn; rewrite ?um_validPt ?valid_initState'//.
-      move=>k; rewrite um_domPt !inE=>/eqP <-.
-      rewrite dom_initState' //.
-      by move/negP: H_ni.
-- move => n.
-  have H_in: n \in enum Address by rewrite mem_enum.
-  have H_un: uniq (enum Address) by apply enum_uniq.
-  move: H_in H_un.
-  elim: (enum Address) => //=.
-  move => a s IH.
-  rewrite inE.
-  move/orP.
-  case.
-  * move/eqP => H_eq /=.
-    rewrite H_eq.
-    move/andP => [H_in H_u].
-    rewrite /holds /= => st.
-    rewrite gen_findPtUn.
-    + case => H_i; rewrite -H_i.
-      by rewrite/has_init_block/blockTree um_findPt.
-    + case: validUn; rewrite ?um_validPt ?valid_initState'//.
-      move=>k; rewrite um_domPt !inE=>/eqP <-.
-      rewrite dom_initState' //.
-      by move/negP: H_in.
-  * move => H_in.
-    move/andP => [H_ni H_u].
-    have H_neq: n <> a.
-      move => H_eq.
-      rewrite -H_eq in H_ni.
-      by move/negP: H_ni.
-    move: H_in.
-    move/IH {IH} => IH.
-    have H_u' := H_u.
-    move: H_u'.
-    move/IH {IH}.
-    rewrite /holds /= => IH st.
-    rewrite findUnL.
-    + case: ifP; last by move => H_in H_f; exact: IH.
-      rewrite um_domPt inE.
-      rewrite eq_sym.
-      by move/eqP.
-    + case: validUn; rewrite ?um_validPt ?valid_initState'//.
-      move=>k; rewrite um_domPt !inE=>/eqP <-.
-      rewrite dom_initState' //.
-      by move/negP: H_ni.
-- move => n.
-  have H_in: n \in enum Address by rewrite mem_enum.
-  have H_un: uniq (enum Address) by apply enum_uniq.
-  move: H_in H_un.
-  elim: (enum Address) => //=.
-  move => a s IH.
-  rewrite inE.
-  move/orP.
-  case.
-  * move/eqP => H_eq /=.
-    rewrite H_eq.
-    move/andP => [H_in H_u].
-    rewrite /holds /= => st.
-    rewrite gen_findPtUn.
-    + by case => H_i; rewrite -H_i.
-    + case: validUn; rewrite ?um_validPt ?valid_initState'//.
-      move=>k; rewrite um_domPt !inE=>/eqP <-.
-      rewrite dom_initState' //.
-      by move/negP: H_in.
-  * move => H_in.
-    move/andP => [H_ni H_u].
-    have H_neq: n <> a.
-      move => H_eq.
-      rewrite -H_eq in H_ni.
-      by move/negP: H_ni.
-    move: H_in.
-    move/IH {IH} => IH.
-    have H_u' := H_u.
-    move: H_u'.
-    move/IH {IH}.
-    rewrite /holds /= => IH st.
-    rewrite findUnL.
-    + case: ifP; last by move => H_in H_f; exact: IH.
-      rewrite um_domPt inE.
-      rewrite eq_sym.
-      by move/eqP.
-    + case: validUn; rewrite ?um_validPt ?valid_initState'//.
-      move=>k; rewrite um_domPt !inE=>/eqP <-.
-      rewrite dom_initState' //.
-      by move/negP: H_ni.
+- by move => n; exact: holds_Init_state.
+- move => n; apply: holds_Init_state.
+  by rewrite /blockTree /= um_validPt.
+- move => n; apply: holds_Init_state.
+  rewrite/validH/blockTree /= => h b H.
+  by move: (um_findPt_inv H); elim=>->->.
+- move => n; apply: holds_Init_state.
+  by rewrite/has_init_block/blockTree um_findPt.
+- move => n; exact: holds_Init_state.
 Qed.
 
 Lemma Coh_step w w' q:
@@ -454,5 +283,3 @@ Proof.
 move=> f S h sF st' s'F.
 by rewrite f in s'F; case: s'F=><-; move: (h st sF).
 Qed.
-
-End Semantics.

--- a/Systems/Network.v
+++ b/Systems/Network.v
@@ -82,20 +82,6 @@ involved peers are not _too different_. *)
 
 Definition initWorld := mkW initState [::] [::].
 
-(*
-Ltac InitState_induction :=
-move=>n st; elim: N=>//=[|n' Hi];
-do? [by move/find_some; rewrite dom0 inE];
-do? [
-  rewrite findUnL; last by [
-    case: validUn; rewrite ?um_validPt ?valid_initState//;
-    move=>k; rewrite um_domPt !inE=>/eqP <-;
-    rewrite dom_initState mem_iota addnC addn1 ltnn andbC
-  ]
-];
-case: ifP=>//; rewrite um_domPt inE=>/eqP<-.
-*)
-
 Ltac Coh_step_case n d H F :=
   case B: (n == d);
   do? [by move=>F; move: (H n _ F) |

--- a/Systems/Network.v
+++ b/Systems/Network.v
@@ -89,9 +89,9 @@ Ltac Coh_step_case n d H F :=
   ]; move=>_ [] <-.
 
 Lemma holds_Init_state : forall (P : State -> Prop) n, P (Init n) ->
-  holds n {| localState := initState' (enum Address); inFlightMsgs := [::]; consumedMsgs := [::] |} (fun st : State => P st).
+  holds n {| localState := initState; inFlightMsgs := [::]; consumedMsgs := [::] |} (fun st : State => P st).
 Proof.
-move => P n H_P.
+move => P n H_P; rewrite /initState.
 have H_in: n \in enum Address by rewrite mem_enum.
 have H_un: uniq (enum Address) by apply enum_uniq.
 move: H_in H_un; elim: (enum Address) => //=.
@@ -117,7 +117,7 @@ Qed.
 
 Lemma Coh_init : Coh initWorld.
 Proof.
-rewrite /initWorld/initState/localState/=; split.
+rewrite /initWorld/localState/=; split.
 - apply: valid_initState'.
   exact: enum_uniq.
 - by move => n; exact: holds_Init_state.

--- a/Systems/Protocol.v
+++ b/Systems/Protocol.v
@@ -1,5 +1,5 @@
 From mathcomp.ssreflect
-Require Import ssreflect ssrbool ssrnat eqtype ssrfun seq.
+Require Import ssreflect ssrbool ssrnat eqtype ssrfun seq fintype.
 From mathcomp
 Require Import path.
 Require Import Eqdep.
@@ -139,7 +139,7 @@ End MsgEq.
 Export MsgEq.
 
 Record Packet := mkP {src: Address; dst: Address; msg: Message}.
-Definition NullPacket := mkP 0 0 NullMsg.
+Definition NullPacket := mkP NullAddress NullAddress NullMsg.
 
 Module PacketEq.
 Definition eq_pkt a b :=

--- a/Systems/States.v
+++ b/Systems/States.v
@@ -1,5 +1,5 @@
 From mathcomp.ssreflect
-Require Import ssreflect ssrbool ssrnat eqtype ssrfun seq.
+Require Import ssreflect ssrbool ssrnat eqtype ssrfun seq fintype.
 From mathcomp
 Require Import path.
 Require Import Eqdep Relations.
@@ -11,60 +11,44 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Section States.
-
-(* Number of nodes *)
-Variable N : nat.
+Definition Address_ordMixin := fin_ordMixin Address.
+Canonical Structure Address_ordType := OrdType Address Address_ordMixin.
 
 Definition StateMap := union_map [ordType of Address] State.
 
-Fixpoint initState' n : StateMap :=
-  if n is n'.+1 then (n \\-> Init n) \+ (initState' n') else Unit.
+Definition initState' s : StateMap := foldr (fun a m => (a \\-> Init a) \+ m) Unit s.
 
 (* Master-lemma, proving a conjunction of two mutually-necessary facts *)
-Lemma initStateValidDom n : dom (initState' n) =i iota 1 n /\ valid (initState' n).
+Lemma initStateValidDom s :
+  uniq s -> dom (initState' s) =i s /\ valid (initState' s).
 Proof.
-elim: n=>/=[|n [H1 H2]]; first by rewrite valid_unit dom0.
+elim: s => /=[|a s']; first by rewrite valid_unit dom0.
+move => IH.
+move/andP => [H_ni H_u].
+move/IH: H_u => [H1 H2] {IH}.
 split; last first.
-- case: validUn; rewrite ?um_validPt ?H2//. 
+- case: validUn; rewrite ?um_validPt ?H2//.
   move=>k; rewrite um_domPt inE=>/eqP Z; subst k.
-  by rewrite H1 mem_iota=>/andP[_]; rewrite add1n ltnn. 
-move=>z; rewrite domUn !inE !um_domPt !inE.
-case B: (z == 1)=>//=.
-- move/eqP: B=>B; subst z=>/=; apply/andP; split; last first.
-  + by rewrite orbC H1 mem_iota/= addnC addn1; case: n {H1 H2}=>//.
-  case: validUn; rewrite ?um_validPt ?H2//. 
-  move=>k; rewrite um_domPt inE=>/eqP Z; subst k.
-  by rewrite H1 mem_iota=>/andP[_]; rewrite add1n ltnn. 
-case C: (z \in iota 2 n).
-- apply/andP; split; last first.
-  + rewrite orbC H1 mem_iota/= addnC addn1; rewrite mem_iota in C.
-    case/andP: C=>H3 H4; rewrite eq_sym.
-    rewrite addnC addn2 in H4; clear B.
-    case B: (z == n.+1); rewrite orbC//=.
-    rewrite ltnS leq_eqVlt B/= in H4.
-    by rewrite H4 andbC/=; by case: {B H4} z H3.
-  case: validUn; rewrite ?um_validPt ?H2//. 
-  move=>k; rewrite um_domPt inE=>/eqP Z; subst k. 
-  by rewrite H1 mem_iota=>/andP[_]; rewrite add1n ltnn. 
-rewrite H1; apply/negP=>/andP[_]/orP[].
-- move/eqP=>Z; subst z; rewrite mem_iota in C.
-  move/negP: C=>C; apply: C; rewrite addnC addn2.
-  rewrite andbC ltnSn/=; clear H1 H2.
-  by move/negbT: B; case: n.
-rewrite !mem_iota in C *=>/andP[]H3 H4.
-move/negP: C=>C; apply: C; apply/andP; split.
-- by clear H4; case: z H3 B=>//z _; case: z=>//.
-rewrite addnC addn1 in H4; rewrite addnC.
-by rewrite addn2 -[n.+2]addn1; apply: ltn_addr. 
+  rewrite H1.
+  by move/negP: H_ni.
+- move=>z; rewrite domUn !inE !um_domPt !inE.
+  rewrite H1.
+  case validUn.
+  * by move/negP => H_v; case: H_v; rewrite um_validPt.
+  * by move/negP.
+  * move => k.
+    rewrite H1.
+    rewrite um_domPt inE=>/eqP H_eq.
+    rewrite -H_eq => H_in.
+    by move/negP: H_ni.
+  * move => Hv1 Hv2 H_d.
+    by rewrite eq_sym.
 Qed.
 
-Lemma valid_initState n : valid (initState' n).
-Proof. by case: (initStateValidDom n). Qed.
+Lemma valid_initState' s : uniq s -> valid (initState' s).
+Proof. by move => H_u; case: (initStateValidDom H_u). Qed.
 
-Lemma dom_initState n : dom (initState' n) =i iota 1 n.
-Proof. by case: (initStateValidDom n). Qed.
+Lemma dom_initState' s : uniq s -> dom (initState' s) =i s.
+Proof. by move => H_u; case: (initStateValidDom H_u). Qed.
 
-Definition initState := initState' N.
-
-End States.
+Definition initState := initState' (enum Address).


### PR DESCRIPTION
Fix for #3. Having an arbitrary `finType` for `Address` gives a lot of flexibility for instantiation (e.g., to use `nat` one just uses `I_n` for some fixed `n`). 

On the other hand, extraction of `finType` has the somewhat annoying property that the `enum` list is computed whenever a module is loaded (not even necessarily used) at runtime. When using concrete types with many members (e.g., all valid IP addresses) this leads to serious problems and must be addressed with extraction directives.