### PR TITLE
Change VAF and genProof signatures to be Bitcoin-compatible

### DIFF
--- a/Structures/Forests.v
+++ b/Structures/Forests.v
@@ -38,7 +38,7 @@ Definition TxPool := seq Transaction.
 Parameter hashT : Transaction -> Hash.
 Parameter hashB : block -> Hash.
 Parameter genProof : Address -> Blockchain -> TxPool -> Timestamp -> option VProof.
-Parameter VAF : VProof -> Timestamp -> Blockchain -> bool.
+Parameter VAF : VProof -> Timestamp -> Blockchain -> TxPool -> bool.
 Parameter FCR : Blockchain -> Blockchain -> bool.
 
 (* Transaction is valid and consistent with the given chain *)
@@ -83,7 +83,7 @@ Axiom hashT_inj : injective hashT.
 (* This axiom seems reasonable: it shouldn't be possible
    to generate a block _from_ the chain it is supposed to tail.  *)
 Axiom VAF_nocycle :
-  forall (b : block) ts (bc : Blockchain), VAF (proof b) ts bc -> b \notin bc.
+  forall (b : block) ts (bc : Blockchain), VAF (proof b) ts bc (txs b) -> b \notin bc.
 
 (* 2. FCR *)
 
@@ -1304,7 +1304,7 @@ Lemma btExtend_mint_ext bt bc b ts :
   bc = compute_chain bt pb ->
   good_chain bc ->
   prevBlockHash b = #pb ->
-  VAF (proof b) ts bc ->
+  VAF (proof b) ts bc (txs b) ->
   compute_chain (btExtend bt b) b = rcons bc b.
 Proof.
 move=>pb V Vh Ib E HGood Hp Hv.
@@ -1372,7 +1372,7 @@ Lemma btExtend_mint_good_valid bt b ts :
   tx_valid_block bc b ->
   good_chain bc ->
   prevBlockHash b = #pb ->
-  VAF (proof b) ts bc ->
+  VAF (proof b) ts bc (txs b) ->
   good_chain (compute_chain (btExtend bt b) b) /\
   tx_valid_chain (compute_chain (btExtend bt b) b).
 Proof.
@@ -1396,7 +1396,7 @@ Lemma btExtend_mint bt b ts :
   valid bt -> validH bt -> has_init_block bt ->
   tx_valid_block (btChain bt) b ->
   prevBlockHash b = # pb ->
-  VAF (proof b) ts (btChain bt) = true ->
+  VAF (proof b) ts (btChain bt) (txs b) = true ->
   btChain (btExtend bt b) > btChain bt.
 Proof.
 move=>lst V Vh Ib T mint Hv.
@@ -1841,7 +1841,7 @@ Lemma btExtend_within cbt bt b bs ts:
   tx_valid_block (btChain bt) b ->
   btChain cbt >= btChain (btExtend bt b) ->
   prevBlockHash b = # last GenesisBlock (btChain bt) ->
-  VAF (proof b) ts (btChain bt) ->
+  VAF (proof b) ts (btChain bt) (txs b) ->
   cbt = foldl btExtend bt bs ->
   btChain (btExtend cbt b) > btChain cbt -> False.
 Proof.
@@ -1897,7 +1897,7 @@ Lemma btExtend_can_eq cbt bt b bs ts:
   tx_valid_block (btChain bt) b ->
   btChain cbt >= btChain (btExtend bt b) ->
   prevBlockHash b = # last GenesisBlock (btChain bt) ->
-  VAF (proof b) ts (btChain bt) ->
+  VAF (proof b) ts (btChain bt) (txs b) ->
   cbt = foldl btExtend bt bs ->
   btChain (btExtend cbt b) = btChain cbt.
 Proof.

--- a/Structures/Forests.v
+++ b/Structures/Forests.v
@@ -37,7 +37,7 @@ Definition TxPool := seq Transaction.
 
 Parameter hashT : Transaction -> Hash.
 Parameter hashB : block -> Hash.
-Parameter genProof : Address -> Blockchain -> TxPool -> option VProof.
+Parameter genProof : Address -> Blockchain -> TxPool -> Timestamp -> option VProof.
 Parameter VAF : VProof -> Timestamp -> Blockchain -> bool.
 Parameter FCR : Blockchain -> Blockchain -> bool.
 

--- a/Structures/Forests.v
+++ b/Structures/Forests.v
@@ -29,17 +29,17 @@ Parameter GenesisBlock : block.
 
 Definition Blockchain := seq block.
 
-(* In fact, it's a forrest, as it also keeps orphan blocks *)
+(* In fact, it's a forest, as it also keeps orphan blocks *)
 Definition BlockTree := union_map Hash block.
-
-Parameter hashT : Transaction -> Hash.
-Parameter hashB : block -> Hash.
-Parameter genProof : Address -> Blockchain -> option VProof.
-Parameter VAF : VProof -> Timestamp -> Blockchain -> bool.
-Parameter FCR : Blockchain -> Blockchain -> bool.
 
 (* Transaction pools *)
 Definition TxPool := seq Transaction.
+
+Parameter hashT : Transaction -> Hash.
+Parameter hashB : block -> Hash.
+Parameter genProof : Address -> Blockchain -> TxPool -> option VProof.
+Parameter VAF : VProof -> Timestamp -> Blockchain -> bool.
+Parameter FCR : Blockchain -> Blockchain -> bool.
 
 (* Transaction is valid and consistent with the given chain *)
 Parameter txValid : Transaction -> Blockchain -> bool.

--- a/Systems/Protocol.v
+++ b/Systems/Protocol.v
@@ -231,9 +231,9 @@ Definition procInt (st : State) (tr : InternalTransition) (ts : Timestamp) :=
       let: allowedTxs := [seq t <- pool | txValid t bc] in
       match genProof n bc allowedTxs ts with
       | Some pf =>
-        let: prevBlock := last GenesisBlock bc in
-        let: block := mkB (hashB prevBlock) allowedTxs pf in
-        if VAF pf ts bc then
+        if VAF pf ts bc allowedTxs then
+          let: prevBlock := last GenesisBlock bc in
+          let: block := mkB (hashB prevBlock) allowedTxs pf in
           if tx_valid_block bc block then
             let: newBt := btExtend bt block in
             let: newPool := [seq t <- pool | txValid t (btChain newBt)] in

--- a/Systems/Protocol.v
+++ b/Systems/Protocol.v
@@ -228,22 +228,21 @@ Definition procInt (st : State) (tr : InternalTransition) (ts : Timestamp) :=
     (* Assumption: nodes broadcast to themselves as well! => simplifies logic *)
     | MintT =>
       let: bc := btChain bt in
-      let: attempt := genProof n bc in
-      match attempt with
+      let: allowedTxs := [seq t <- pool | txValid t bc] in
+      match genProof n bc allowedTxs with
       | Some pf =>
-          if VAF pf ts bc then
-            let: allowedTxs := [seq t <- pool | txValid t bc] in
-            let: prevBlock := last GenesisBlock bc in
-            let: block := mkB (hashB prevBlock) allowedTxs pf in
-            if tx_valid_block bc block then
-              let: newBt := btExtend bt block in
-              let: newPool := [seq t <- pool | txValid t (btChain newBt)] in
-              let: ownHashes := (keys_of newBt) ++ [seq hashT t | t <- newPool] in
-              pair (Node n prs newBt newPool) (emitBroadcast n prs (BlockMsg block))
-            else
-              pair st emitZero
+        let: prevBlock := last GenesisBlock bc in
+        let: block := mkB (hashB prevBlock) allowedTxs pf in
+        if VAF pf ts bc then
+          if tx_valid_block bc block then
+            let: newBt := btExtend bt block in
+            let: newPool := [seq t <- pool | txValid t (btChain newBt)] in
+            let: ownHashes := (keys_of newBt) ++ [seq hashT t | t <- newPool] in
+            pair (Node n prs newBt newPool) (emitBroadcast n prs (BlockMsg block))
           else
             pair st emitZero
+        else
+          pair st emitZero
       | None => pair st emitZero
       end
     end.

--- a/Systems/Protocol.v
+++ b/Systems/Protocol.v
@@ -229,7 +229,7 @@ Definition procInt (st : State) (tr : InternalTransition) (ts : Timestamp) :=
     | MintT =>
       let: bc := btChain bt in
       let: allowedTxs := [seq t <- pool | txValid t bc] in
-      match genProof n bc allowedTxs with
+      match genProof n bc allowedTxs ts with
       | Some pf =>
         let: prevBlock := last GenesisBlock bc in
         let: block := mkB (hashB prevBlock) allowedTxs pf in
@@ -259,7 +259,8 @@ Qed.
 Lemma procInt_id_constant : forall (s1 : State) (t : InternalTransition) (ts : Timestamp),
     id s1 = id (procInt s1 t ts).1.
 Proof.
-case=> n1 p1 b1 t1 [] =>//; simpl; case hP: (genProof _)=>ts //; case vP: (VAF _)=>//.
+case=> n1 p1 b1 t1 [] =>// ts; simpl.
+case hP: genProof => //; case vP: (VAF _)=>//.
 case tV: (tx_valid_block _ _)=>//.
 Qed.
 


### PR DESCRIPTION
One basic check for the reasonableness of the parameters/axioms is whether they can be instantiated for Bitcoin. Here are changes to some signature that make it possible to support regular Bitcoin.