### PR TITLE
Metadata for Travis

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -ev
+
+eval $(opam config env)
+
+opam update
+
+opam pin add toychain . --yes --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,52 @@
+language: generic
+sudo: false
+
+services:
+  - docker
+
+env:
+  global:
+    - THIS_REPO=toychain
+    - COQ_VERSION=coq8.7-32bit
+
+# The "docker run" command will pull if needed.
+# Running this first gives two tries in case of network lossage.
+before_script:
+  - timeout 5m docker pull mdernst/xenial-for-verdi-$COQ_VERSION || true
+
+# Using travis_wait here seems to cause the job to terminate after 1 minute
+# with no error (!).
+# The git commands are tried twice, in case of temporary network failure.
+# The fcntl line works around a bug where Travis truncates logs and fails.
+script:
+  - python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
+  - REMOTE_ORIGIN_URL=`git config --get remote.origin.url`
+  - echo "THIS_REPO=${THIS_REPO}"
+  - echo "COQ_VERSION=${COQ_VERSION}"
+  - echo "TRAVIS_BRANCH=${TRAVIS_BRANCH}"
+  - echo "REMOTE_ORIGIN_URL=${REMOTE_ORIGIN_URL}"
+  - echo "TRAVIS_EVENT_TYPE=${TRAVIS_EVENT_TYPE}"
+  - echo "TRAVIS_COMMIT=${TRAVIS_COMMIT}"
+  - echo "TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST}"
+  - echo "TRAVIS_PULL_REQUEST_BRANCH=${TRAVIS_PULL_REQUEST_BRANCH}"
+  - echo "TRAVIS_PULL_REQUEST_SHA=${TRAVIS_PULL_REQUEST_SHA}"
+  - echo "TRAVIS_REPO_SLUG=${TRAVIS_REPO_SLUG}"
+  - >-
+    docker run mdernst/xenial-for-verdi-$COQ_VERSION /bin/bash -c "true &&
+       if [ $TRAVIS_EVENT_TYPE = pull_request ] ; then
+         git clone --quiet --depth 9 $REMOTE_ORIGIN_URL $THIS_REPO || git clone --quiet --depth 9 $REMOTE_ORIGIN_URL $THIS_REPO
+         cd $THIS_REPO
+         git fetch origin +refs/pull/$TRAVIS_PULL_REQUEST/merge
+         git checkout -qf $TRAVIS_PULL_REQUEST_SHA
+       else
+         git clone --quiet --depth 9 -b $TRAVIS_BRANCH $REMOTE_ORIGIN_URL $THIS_REPO || git clone --quiet --depth 9 -b $TRAVIS_BRANCH $REMOTE_ORIGIN_URL $THIS_REPO
+         cd $THIS_REPO
+         git checkout -qf $TRAVIS_COMMIT
+       fi &&
+       ./.travis-ci.sh"
+
+git:
+  depth: 9
+
+notifications:
+  email: false

--- a/opam
+++ b/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+version: "dev"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/certichain/toychain"
+dev-repo: "https://github.com/certichain/toychain.git"
+bug-reports: "https://github.com/certichain/toychain/issues"
+license: "BSD"
+
+build: [
+  [ make "-j%{jobs}%" ]
+]
+depends: [
+  "coq" {>= "8.7" & < "8.8~"}
+  "coq-mathcomp-ssreflect" {>= "1.6" & < "1.7~"}
+]
+
+tags: [
+  "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems"
+  "keyword:program verification"
+  "keyword:distributed algorithms"
+]
+authors: [
+  "Ilya Sergey <>"
+  "George Pirlea <>"
+  "Karl Palmskog <>"
+]


### PR DESCRIPTION
Here are metadata files for enabling Travis CI for this repository. This allows continuous checking that changes do not break proofs.

@dranov Is there any chance you could enable Travis by connecting your Github account to [Travis CI](https://travis-ci.org) and then selecting the appropriate button on your Travis profile? See [here](https://docs.travis-ci.com/user/getting-started/) for some more information.

(I currently don't have access rights to enable Travis for this repository, but I tested that the metadata works in my fork.)