### PR TITLE
Modify genProof to allow coinbase transactions

### DIFF
--- a/Properties/InvCliqueTopology.v
+++ b/Properties/InvCliqueTopology.v
@@ -413,13 +413,13 @@ case: GSyncW=>can_bc [can_bt] [can_n] []
 case: t P P'=>[tx|] P P'; last first.
 (* MintT - can_bc and can_n might change *)
 - assert (PInt := P); move: P; destruct st; rewrite/procInt.
-  case X: (genProof _)=>[[allTxs pf]|].
+  case X: (genProof _)=>[[txs pf]|].
   case Y: (VAF _).
   case Z: (tx_valid_block _ _).
   (* This is the only interesting case - when a new block is minted *)
   set new_block :=
     {| prevBlockHash := # last GenesisBlock (btChain blockTree);
-       txs := allTxs;
+       txs := txs;
        proof := pf
     |}.
   set new_txpool :=

--- a/Properties/InvCliqueTopology.v
+++ b/Properties/InvCliqueTopology.v
@@ -413,13 +413,13 @@ case: GSyncW=>can_bc [can_bt] [can_n] []
 case: t P P'=>[tx|] P P'; last first.
 (* MintT - can_bc and can_n might change *)
 - assert (PInt := P); move: P; destruct st; rewrite/procInt.
-  case X: (genProof _)=>[pf|].
+  case X: (genProof _)=>[[allTxs pf]|].
   case Y: (VAF _).
   case Z: (tx_valid_block _ _).
   (* This is the only interesting case - when a new block is minted *)
   set new_block :=
     {| prevBlockHash := # last GenesisBlock (btChain blockTree);
-       txs := [seq t <- txPool | txValid t (btChain blockTree)];
+       txs := allTxs;
        proof := pf
     |}.
   set new_txpool :=

--- a/Structures/Chains.v
+++ b/Structures/Chains.v
@@ -7,8 +7,6 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Section BlockchainOrder.
-
 (* Strict version of the prefix *)
 Definition is_strict_prefix {T: eqType} (bc bc' : seq T) :=
   exists b bc1, bc' = bc ++ (b :: bc1).
@@ -139,13 +137,9 @@ apply/Bool.eq_iff_eq_true; split.
   by move/eqP=><-; apply/prefixP; apply bc_pre_refl.
   by move/sprefixP=>[] x [] xs eq; apply/prefixP; rewrite eq; exists (x :: xs).
 Qed.
-  
-End BlockchainOrder.
 
 Notation "'[' bc1 '<<=' bc2 ']'" := (is_prefix bc1 bc2).
 Notation "'[' bc1 '<<<' bc2 ']'" := (is_strict_prefix bc1 bc2).
-
-Section Forks.
 
 (* Decidable fork *)
 Definition fork {T: eqType} (bc1 bc2 : seq T) :=
@@ -169,7 +163,7 @@ case/orP.
   by left; eexists _.
   by rewrite orbC eq_sym -prb_equiv=>P21; apply: G; right; apply/prefixP.
 Qed.
-  
+
 Lemma bc_fork_neq {T: eqType} (bc bc' : seq T) :
   fork bc bc' -> bc != bc'.
 Proof.
@@ -226,5 +220,3 @@ do? by [
 - by contradict F; move/norP=>[] _=>/norP; elim=>C; rewrite S21 in C.
 - by contradict F; rewrite/fork Eq S12 S21.
 Qed.
-
-End Forks.

--- a/Structures/Forests.v
+++ b/Structures/Forests.v
@@ -102,6 +102,11 @@ Axiom FCR_nrefl :
 Axiom FCR_trans :
   forall (A B C : Blockchain), A > B -> B > C -> A > C.
 
+Axiom genProof_subseq :
+  forall (a : Address) (bc : Blockchain) (txs : TxPool) (ts : Timestamp) (txs' : TxPool) (pf : VProof),
+    genProof a bc txs ts = Some (txs', pf) ->
+    subseq txs txs'.
+
 (************************************************************)
 (*********************** </axioms> **************************)
 (************************************************************)

--- a/Structures/Forests.v
+++ b/Structures/Forests.v
@@ -38,7 +38,7 @@ Definition TxPool := seq Transaction.
 
 Parameter hashT : Transaction -> Hash.
 Parameter hashB : block -> Hash.
-Parameter genProof : Address -> Blockchain -> TxPool -> Timestamp -> option VProof.
+Parameter genProof : Address -> Blockchain -> TxPool -> Timestamp -> option (TxPool * VProof).
 Parameter VAF : VProof -> Timestamp -> Blockchain -> TxPool -> bool.
 Parameter FCR : Blockchain -> Blockchain -> bool.
 

--- a/Systems/Protocol.v
+++ b/Systems/Protocol.v
@@ -230,10 +230,10 @@ Definition procInt (st : State) (tr : InternalTransition) (ts : Timestamp) :=
       let: bc := btChain bt in
       let: allowedTxs := [seq t <- pool | txValid t bc] in
       match genProof n bc allowedTxs ts with
-      | Some (allTxs, pf) =>
-        if VAF pf ts bc allTxs then
+      | Some (txs, pf) =>
+        if VAF pf ts bc txs then
           let: prevBlock := last GenesisBlock bc in
-          let: block := mkB (hashB prevBlock) allTxs pf in
+          let: block := mkB (hashB prevBlock) txs pf in
           if tx_valid_block bc block then
             let: newBt := btExtend bt block in
             let: newPool := [seq t <- pool | txValid t (btChain newBt)] in

--- a/Systems/Protocol.v
+++ b/Systems/Protocol.v
@@ -260,7 +260,7 @@ Lemma procInt_id_constant : forall (s1 : State) (t : InternalTransition) (ts : T
     id s1 = id (procInt s1 t ts).1.
 Proof.
 case=> n1 p1 b1 t1 [] =>// ts; simpl.
-case hP: genProof => [[allTxs pf]|] //.
+case hP: genProof => [[txs pf]|] //.
 case vP: (VAF _)=>//.
 case tV: (tx_valid_block _ _)=>//.
 Qed.
@@ -283,7 +283,7 @@ Lemma procInt_valid :
 Proof.
 move=>s1 t ts.
 case Int: t; destruct s1; rewrite/procInt/=; first by [].
-case: genProof => [[allTxs pf]|]; last done.
+case: genProof => [[txs pf]|]; last done.
 case: (VAF _ _ _); last done.
 case tV: (tx_valid_block _ _)=>//.
 by rewrite/blockTree/=; apply btExtendV.
@@ -309,7 +309,7 @@ Lemma procInt_validH :
 Proof.
 move=>s1 t ts v vh.
 case Int: t; destruct s1; rewrite/procInt/=; first by [].
-case: genProof => [[allTxs pf]|]; last by [].
+case: genProof => [[txs pf]|]; last by [].
 case: (VAF _ _ _); last done.
 case tV: (tx_valid_block _ _)=>//.
 by rewrite/blockTree/=; apply btExtendH.
@@ -337,7 +337,7 @@ Lemma procInt_has_init_block :
 Proof.
 move=>s1 t ts v vh.
 case Int: t; destruct s1; rewrite/procInt/=; first by [].
-case: genProof => [[allTxs pf]|]; last by [].
+case: genProof => [[txs pf]|]; last by [].
 case: (VAF _ _ _); last done.
 case tV: (tx_valid_block _ _)=>//.
 by apply btExtendIB.
@@ -424,7 +424,7 @@ Lemma procInt_peers_uniq :
     uniq (peers s1) -> uniq (peers s2).
 Proof.
 move=>s1 t ts; case: s1=>n prs bt txp; rewrite /peers/procInt=>Up.
-case: t=>//; case hP: genProof => [[allTxs pf]|]//; case vP: (VAF _)=>//.
+case: t=>//; case hP: genProof => [[txs pf]|]//; case vP: (VAF _)=>//.
 case tV: (tx_valid_block _ _)=>//.
 Qed.
 


### PR DESCRIPTION
Coinbase transactions in Bitcoin are [added](https://github.com/bitcoin/bitcoin/blob/ad960f5771dc251c8e1198dd8a82e18df4562171/src/miner.cpp#L153) to a block by miners to get compensation for their work, and also contains the height of the block. These transactions are currently impossible to account for in Toychain, since blocks can contain only transactions that have been added to a node's transaction pool.

Here is the best solution I could think of to make coinbase transactions possible: modify the `genProof` function to return both a proof of work/stake and all the transactions to add to the block: `genProof : Address -> Blockchain -> TxPool -> Timestamp -> option (TxPool * VProof).`

As it turns out, all current properties still hold with this change, even without the "obvious" property that the transactions output from `genProof` comprise a superset of the input transactions. Nevertheless, I added an axiom to this effect for use in future proofs.

Unless I hear any objections, I will merge this in the near future. General comments also welcome.