### PR TITLE
Incorporate VAF into chain validity checking

### DIFF
--- a/Properties/InvCliqueTopology.v
+++ b/Properties/InvCliqueTopology.v
@@ -445,7 +445,7 @@ case: t P P'=>[tx|] P P'; last first.
       set lst := last GenesisBlock (btChain blockTree).
       (have:  prevBlockHash new_block = # lst by [])=>Hp.
       (have: btChain blockTree \in all_chains blockTree by move: (btChain_in_bt (c5 _ _ F)))=>InC.
-      move: (@btExtend_mint_good_valid _ new_block (ts q) (c3 _ _ F) (c4 _ _ F)
+      move: (@btExtend_mint_good_valid _ new_block (c3 _ _ F) (c4 _ _ F)
               (c5 _ _ F) Z  (btChain_good blockTree) Hp Y)=>Gc.
       move: (HExt _ _ F)=>/= Eq; rewrite Eq.
       rewrite -(@foldl1 BlockTree Block btExtend (foldl _ _ _)) btExtend_fold_comm /=.
@@ -508,8 +508,7 @@ case: t P P'=>[tx|] P P'; last first.
     contradict Gt; move/eqP in Dst; subst can_n.
     suff W: (btChain (btExtend blockTree new_block) > can_bc) by rewrite W.
     move: (HHold _ F); rewrite/has_chain/==>/eqP <-.
-    by apply: (@btExtend_mint _ new_block (ts q)
-                              (c3 _ _ F)(c4 _ _ F)(c5 _ _ F)).
+    by apply: (@btExtend_mint _ new_block (c3 _ _ F)(c4 _ _ F)(c5 _ _ F)).
 
     (* HGood *)
     have HGood': good_bt (btExtend can_bt new_block).
@@ -525,7 +524,7 @@ case: t P P'=>[tx|] P P'; last first.
       set lst := last GenesisBlock (btChain blockTree).
       (have:  prevBlockHash new_block = # lst by [])=>Hp.
       (have: btChain blockTree \in all_chains blockTree by move: (btChain_in_bt (c5 _ _ F)))=>InC.
-      move: (@btExtend_mint_good_valid _ new_block (ts q) (c3 _ _ F) (c4 _ _ F)
+      move: (@btExtend_mint_good_valid _ new_block (c3 _ _ F) (c4 _ _ F)
               (c5 _ _ F) Z (btChain_good blockTree) Hp Y)=>Gc.
       move: (HExt _ _ F)=>/= Eq; rewrite Eq.
       rewrite -(@foldl1 BlockTree Block btExtend (foldl _ _ _)) btExtend_fold_comm /=.
@@ -560,7 +559,7 @@ case: t P P'=>[tx|] P P'; last first.
     move: (HExt _ _ F)=>/= H; move/FCR_dual:Gt=>Gt. 
     case: (btExtend_sameOrBetter new_block C1 C2 C3)=>//Gt1.
     have P : prevBlockHash new_block = # last GenesisBlock (btChain blockTree) by [].
-    by move: (@btExtend_within can_bt _ new_block _ (ts q) C1 C2
+    by move: (@btExtend_within can_bt _ new_block _ C1 C2
                C3 (c3 _ _ F) (c4 _ _ F) (c5 _ _ F) HGood HGood' Z Gt P Y H Gt1).
    
     (* HCliq *)

--- a/Properties/InvCliqueTopology.v
+++ b/Properties/InvCliqueTopology.v
@@ -415,7 +415,6 @@ case: t P P'=>[tx|] P P'; last first.
 (* MintT - can_bc and can_n might change *)
 - assert (PInt := P); move: P; destruct st; rewrite/procInt.
   case X: (genProof _)=>[[txs pf]|].
-  case Y: (VAF _).
   case Z: (valid_chain_block _ _).
   (* This is the only interesting case - when a new block is minted *)
   set new_block :=
@@ -446,7 +445,7 @@ case: t P P'=>[tx|] P P'; last first.
       (have:  prevBlockHash new_block = # lst by [])=>Hp.
       (have: btChain blockTree \in all_chains blockTree by move: (btChain_in_bt (c5 _ _ F)))=>InC.
       move: (@btExtend_mint_good_valid _ new_block (c3 _ _ F) (c4 _ _ F)
-              (c5 _ _ F) Z  (btChain_good blockTree) Hp Y)=>Gc.
+              (c5 _ _ F) Z  (btChain_good blockTree) Hp)=>Gc.
       move: (HExt _ _ F)=>/= Eq; rewrite Eq.
       rewrite -(@foldl1 BlockTree Block btExtend (foldl _ _ _)) btExtend_fold_comm /=.
       move: (c3 _ _ F)=>/=; rewrite (btExtendV blockTree new_block)=>V'.
@@ -525,7 +524,7 @@ case: t P P'=>[tx|] P P'; last first.
       (have:  prevBlockHash new_block = # lst by [])=>Hp.
       (have: btChain blockTree \in all_chains blockTree by move: (btChain_in_bt (c5 _ _ F)))=>InC.
       move: (@btExtend_mint_good_valid _ new_block (c3 _ _ F) (c4 _ _ F)
-              (c5 _ _ F) Z (btChain_good blockTree) Hp Y)=>Gc.
+              (c5 _ _ F) Z (btChain_good blockTree) Hp)=>Gc.
       move: (HExt _ _ F)=>/= Eq; rewrite Eq.
       rewrite -(@foldl1 BlockTree Block btExtend (foldl _ _ _)) btExtend_fold_comm /=.
       move: (c3 _ _ F)=>/=; rewrite (btExtendV blockTree new_block)=>V'.
@@ -560,7 +559,7 @@ case: t P P'=>[tx|] P P'; last first.
     case: (btExtend_sameOrBetter new_block C1 C2 C3)=>//Gt1.
     have P : prevBlockHash new_block = # last GenesisBlock (btChain blockTree) by [].
     by move: (@btExtend_within can_bt _ new_block _ C1 C2
-               C3 (c3 _ _ F) (c4 _ _ F) (c5 _ _ F) HGood HGood' Z Gt P Y H Gt1).
+               C3 (c3 _ _ F) (c4 _ _ F) (c5 _ _ F) HGood HGood' Z Gt P H Gt1).
    
     (* HCliq *)
     procInt_clique_maintain proc n st w F Fn Cw Al PInt PInt' P' HCliq H1 H2 c1 z.
@@ -577,7 +576,6 @@ case: t P P'=>[tx|] P P'; last first.
        rewrite (broadcast_reduce _ _ (Cliq n (find_some F')) (c6 _ _ F)) /=;
        do? [rewrite -(btExtend_idemp _ (c3 _ _ F))].
 
-  + no_change can_bc can_bt can_n w F F' HExt c5.
   + no_change can_bc can_bt can_n w F F' HExt c5.
   + no_change can_bc can_bt can_n w F F' HExt c5.
 

--- a/Properties/InvCliqueTopology.v
+++ b/Properties/InvCliqueTopology.v
@@ -416,7 +416,7 @@ case: t P P'=>[tx|] P P'; last first.
 - assert (PInt := P); move: P; destruct st; rewrite/procInt.
   case X: (genProof _)=>[[txs pf]|].
   case Y: (VAF _).
-  case Z: (tx_valid_block _ _).
+  case Z: (valid_chain_block _ _).
   (* This is the only interesting case - when a new block is minted *)
   set new_block :=
     {| prevBlockHash := # last GenesisBlock (btChain blockTree);

--- a/Structures/Forests.v
+++ b/Structures/Forests.v
@@ -1392,14 +1392,13 @@ Lemma btExtend_mint_good_valid bt b :
   valid_chain_block bc b ->
   good_chain bc ->
   prevBlockHash b = #pb ->
-  VAF (proof b) bc (txs b) ->
   good_chain (compute_chain (btExtend bt b) b) /\
   valid_chain (compute_chain (btExtend bt b) b).
 Proof.
-move=>bc pb V Vh Ib Tb Gc Hp Hv.
+move=>bc pb V Vh Ib Tb Gc Hv.
 (have: bc \in all_chains bt by move: (btChain_in_bt Ib))=>InC.
 (have: bc = compute_chain bt pb by move: (chain_from_last V Vh Ib InC))=>C.
-move: (btExtend_mint_ext V Vh Ib C Gc Hp Hv)=>->; subst bc.
+move: (btExtend_mint_ext V Vh Ib C Gc Hv)=>->; subst bc; last by move/andP: Tb => [Hv' Hi].
 rewrite/good_chain. case X: (rcons _ _)=>[|x xs].
 contradict X; elim: (btChain bt)=>//.
 have: (good_chain (btChain bt) = true)by [].
@@ -1416,16 +1415,16 @@ Lemma btExtend_mint bt b :
   valid bt -> validH bt -> has_init_block bt ->
   valid_chain_block (btChain bt) b ->
   prevBlockHash b = # pb ->
-  VAF (proof b) (btChain bt) (txs b) = true ->
   btChain (btExtend bt b) > btChain bt.
 Proof.
-move=>lst V Vh Ib T mint Hv.
+move=>lst V Vh Ib T mint.
 have HGood: good_chain (rcons (btChain bt) b).
 - by move: (btChain_good bt); rewrite {1}/good_chain; case (btChain bt).
 have Hvalid: valid_chain (rcons (btChain bt) b).
 - by move: (btChain_tx_valid bt); apply: valid_chain_last.
 have E: compute_chain (btExtend bt b) b = rcons (btChain bt) b.
-- apply: (@btExtend_mint_ext _ (btChain bt) b V Vh
+- move/andP: T => [Hv Ht].
+  apply: (@btExtend_mint_ext _ (btChain bt) b V Vh
                              Ib _ (btChain_good bt) mint Hv).
   by move/(chain_from_last V Vh Ib): (btChain_in_bt Ib).
 have HIn : rcons (btChain bt) b \in
@@ -1861,14 +1860,13 @@ Lemma btExtend_within cbt bt b bs :
   valid_chain_block (btChain bt) b ->
   btChain cbt >= btChain (btExtend bt b) ->
   prevBlockHash b = # last GenesisBlock (btChain bt) ->
-  VAF (proof b) (btChain bt) (txs b) ->
   cbt = foldl btExtend bt bs ->
   btChain (btExtend cbt b) > btChain cbt -> False.
 Proof.
-move=>V Vh Hib Vl Vhl Hil Hg Hg' T Geq P Vf Ec Cont.
+move=>V Vh Hib Vl Vhl Hil Hg Hg' T Geq P Ec Cont.
 case Nb: (#b \in dom cbt); first by rewrite /btExtend Nb in Cont; apply: FCR_nrefl Cont.
 case: (btExtend_good_split V Vh Hib Hg (negbT Nb) Hg')=>cs1[cs2][Eg][Eg'].
-move: (btExtend_mint_good_valid Vl Vhl Hil T (btChain_good bt) P Vf)=>[Gb Tb].
+move: (btExtend_mint_good_valid Vl Vhl Hil T (btChain_good bt) P)=>[Gb Tb].
 move: (FCR_trans_eq2 Cont Geq)=>Gt'.
 
 have v1': (valid (btExtend bt b)) by rewrite -btExtendV.
@@ -1917,13 +1915,12 @@ Lemma btExtend_can_eq cbt bt b bs :
   valid_chain_block (btChain bt) b ->
   btChain cbt >= btChain (btExtend bt b) ->
   prevBlockHash b = # last GenesisBlock (btChain bt) ->
-  VAF (proof b) (btChain bt) (txs b) ->
   cbt = foldl btExtend bt bs ->
   btChain (btExtend cbt b) = btChain cbt.
 Proof.
-move=>V Vh Hib Vl Vhl Hil Hg Hg' T Geq P Vf Ec.
+move=>V Vh Hib Vl Vhl Hil Hg Hg' T Geq P Ec.
 case: (btExtend_sameOrBetter b V Vh Hib)=>//H1.
-by move: (btExtend_within V Vh Hib Vl Vhl Hil Hg Hg' T Geq P Vf Ec H1). 
+by move: (btExtend_within V Vh Hib Vl Vhl Hil Hg Hg' T Geq P Ec H1).
 Qed.
 
 End BtChainProperties.

--- a/Structures/Forests.v
+++ b/Structures/Forests.v
@@ -80,6 +80,8 @@ Axiom hashT_inj : injective hashT.
 Axiom VAF_nocycle :
   forall (b : block) (bc : Blockchain), VAF (proof b) bc (txs b) -> b \notin bc.
 
+Axiom VAF_init : VAF (proof GenesisBlock) [::] (txs GenesisBlock).
+
 (* 2. FCR *)
 
 Axiom FCR_subchain :
@@ -395,21 +397,20 @@ Definition good_chain (bc : Blockchain) :=
   if bc is h :: _ then h == GenesisBlock else false.
 
 (* Transaction validity *)
-Fixpoint tx_valid_chain' (bc prefix : seq block) :=
+Fixpoint valid_chain' (bc prefix : seq block) :=
   if bc is b :: bc'
-  then [&& all [pred t | txValid t prefix] (txs b) &
-        tx_valid_chain' bc' (rcons prefix b)]
+  then [&& VAF (proof b) prefix (txs b) && all [pred t | txValid t prefix] (txs b) & valid_chain' bc' (rcons prefix b)]
   else true.
 
-Definition tx_valid_chain bc := tx_valid_chain' bc [::].
+Definition valid_chain bc := valid_chain' bc [::].
 
 Definition all_chains bt := [seq compute_chain bt b | b <- all_blocks bt].
 
-Definition good_chains bt := [seq c <- all_chains bt | good_chain c && tx_valid_chain c].
+Definition good_chains bt := [seq c <- all_chains bt | good_chain c && valid_chain c].
 
 (* Get the blockchain *)
 Definition take_better_bc bc2 bc1 :=
-  if (good_chain bc2 && tx_valid_chain bc2) && (bc2 > bc1) then bc2 else bc1.
+  if (good_chain bc2 && valid_chain bc2) && (bc2 > bc1) then bc2 else bc1.
 
 Definition btChain bt : Blockchain :=
   foldr take_better_bc [:: GenesisBlock] (all_chains bt).
@@ -762,8 +763,8 @@ Lemma better_chains1 bt b :
   let f' := bc_fun (# b \\-> b \+ bt) in
   forall h bc' bc,
     bc' >= bc ->
-    tx_valid_chain bc' /\ good_chain bc' ->
-    tx_valid_chain bc /\ good_chain bc ->
+    valid_chain bc' /\ good_chain bc' ->
+    valid_chain bc /\ good_chain bc ->
     f' h bc' >= f h bc.
 Proof.
 move=>V B Vh H/=h bc' bc Gt [T' Gb'] [T Gb]; rewrite /bc_fun/=.
@@ -813,15 +814,16 @@ apply/andP; split => //.
 exact: txValid_nil.
 Qed.
 
-Lemma tx_valid_chain_init : tx_valid_chain [:: GenesisBlock].
+Lemma valid_chain_init : valid_chain [:: GenesisBlock].
 Proof.
-rewrite /tx_valid_chain/=; apply/andP; split => //.
-exact: tx_valid_init.
+rewrite /valid_chain/=; apply/andP; split => //.
+apply/andP; split; last by apply tx_valid_init.
+exact: VAF_init.
 Qed.
 
 Lemma good_chain_foldr bt bc ks :
-  tx_valid_chain bc -> good_chain bc ->
-  tx_valid_chain (foldr (bc_fun bt) bc ks) /\
+  valid_chain bc -> good_chain bc ->
+  valid_chain (foldr (bc_fun bt) bc ks) /\
   good_chain (foldr (bc_fun bt) bc ks).
 Proof.
 elim: ks=>//=x xs Hi T G; rewrite /bc_fun/take_better_bc/= in Hi *.
@@ -830,17 +832,17 @@ by apply: Hi.
 Qed.
 
 Lemma good_chain_foldr_init bt ks :
-  tx_valid_chain (foldr (bc_fun bt) [:: GenesisBlock] ks) /\
+  valid_chain (foldr (bc_fun bt) [:: GenesisBlock] ks) /\
   good_chain (foldr (bc_fun bt) [:: GenesisBlock] ks).
 Proof.
-move: (@good_chain_foldr bt [:: GenesisBlock] ks tx_valid_chain_init)=>/=.
+move: (@good_chain_foldr bt [:: GenesisBlock] ks valid_chain_init)=>/=.
 by rewrite eqxx=>/(_ is_true_true); case.
 Qed.
 
 Lemma good_foldr_init bt ks : good_chain (foldr (bc_fun bt) [:: GenesisBlock] ks).
 Proof. by case: (good_chain_foldr_init bt ks). Qed.
 
-Lemma tx_valid_foldr_init bt ks : tx_valid_chain (foldr (bc_fun bt) [:: GenesisBlock] ks).
+Lemma tx_valid_foldr_init bt ks : valid_chain (foldr (bc_fun bt) [:: GenesisBlock] ks).
 Proof. by case: (good_chain_foldr_init bt ks). Qed.
 
 Lemma better_chains_foldr bt b :
@@ -850,8 +852,8 @@ Lemma better_chains_foldr bt b :
   let f' := bc_fun (# b \\-> b \+ bt) in
   forall ks bc' bc,
     bc' >= bc ->
-    tx_valid_chain bc' /\ good_chain bc' ->
-    tx_valid_chain bc /\ good_chain bc ->
+    valid_chain bc' /\ good_chain bc' ->
+    valid_chain bc /\ good_chain bc ->
     foldr f' bc' ks >= foldr f bc ks.
 Proof.
 move=>V B Vh H f f'; elim=>//h hs Hi bc' bc Gt TG1 TG2 /=.
@@ -882,7 +884,7 @@ do? [apply good_chain_foldr_init=>//]; [by apply/negbT| |]; last first.
 simpl; rewrite {1 3}/f'/bc_fun/=/take_better_bc/=.
 case:ifP=>///andP[B1 B2]. right.
 apply: (FCR_trans_eq2 B2).
-by apply: better_chains_foldr=>//=; [by apply/negbT|by left | |]; do?[rewrite ?tx_valid_chain_init ?eqxx//].
+by apply: better_chains_foldr=>//=; [by apply/negbT|by left | |]; do?[rewrite ?valid_chain_init ?eqxx//].
 Qed.
 
 Lemma btExtend_fold_comm (bt : BlockTree) (bs bs' : seq block) :
@@ -1137,10 +1139,10 @@ rewrite {1}/take_better_bc; case:ifP=>//.
 by case/andP=>/andP[->].
 Qed.
 
-Lemma btChain_tx_valid bt : tx_valid_chain (btChain bt).
+Lemma btChain_tx_valid bt : valid_chain (btChain bt).
 Proof.
 rewrite /btChain.
-elim: (all_chains bt)=>[|bc bcs Hi]/=;first by rewrite tx_valid_chain_init.
+elim: (all_chains bt)=>[|bc bcs Hi]/=;first by rewrite valid_chain_init.
 rewrite {1}/take_better_bc; case:ifP=>//.
 by case/andP=>/andP[_ ->].
 Qed.
@@ -1358,38 +1360,41 @@ elim: n b bt hs Es En D F=>[|n Hi] b bt hs Es En D F/=.
 by rewrite Es D; case (find _ _)=>[?|]//; rewrite last_rcons.
 Qed.
 
-Definition tx_valid_block bc (b : block) := all [pred t | txValid t bc] (txs b).
+Definition valid_chain_block bc (b : block) :=
+  [&& VAF (proof b) bc (txs b) & all [pred t | txValid t bc] (txs b)].
 
-Lemma tx_valid_last_ind c b prefix:
+Lemma valid_chain_last_ind c b prefix:
+  VAF (proof b) prefix (txs b) ->
   all [pred t | txValid t prefix] (txs b) ->
-  tx_valid_chain' c (rcons prefix b) ->
-  tx_valid_chain' (b :: c) prefix.
+  valid_chain' c (rcons prefix b) ->
+  valid_chain' (b :: c) prefix.
 Proof. by move=>/=->->. Qed.
 
-Lemma tx_valid_last c b :
-  tx_valid_block c b -> tx_valid_chain c -> tx_valid_chain (rcons c b).
+Lemma valid_chain_last bc b :
+  valid_chain_block bc b -> valid_chain bc -> valid_chain (rcons bc b).
 Proof.
 move=>H1.
-have P : all [pred t | txValid t c] (txs b) by [].
-have Z: c = [::] ++ c by rewrite ?cats0 ?cat0s.
-rewrite Z in P; rewrite /tx_valid_chain; clear Z.
-move: [::] P => p.
-elim: {-1}c p H1.
-- by move=>p _ /= A _; rewrite cats0 in A; rewrite A.
-move=>x xs Hi p T A/=/andP[Z1 Z2]; rewrite Z1//=.
-by apply: (Hi (rcons p x) T _ Z2); rewrite cat_rcons.
+have H2 := H1.
+move/andP: H2 => [P1 P2].
+have Z: bc = [::] ++ bc by rewrite ?cats0 ?cat0s.
+rewrite Z in P1, P2; rewrite /valid_chain; clear Z.
+move: [::] P1 P2 => p.
+elim: {-1}bc p H1.
+- by move=>p _ /= A B _; rewrite cats0 in A, B; rewrite A B.
+move=>x xs Hi p T A B/=/andP[Z1 Z2]; rewrite Z1//=.
+by apply: (Hi (rcons p x) T _ _ Z2); rewrite cat_rcons.
 Qed.
 
 Lemma btExtend_mint_good_valid bt b :
   let bc := btChain bt in
   let pb := last GenesisBlock bc in
   valid bt -> validH bt -> has_init_block bt ->
-  tx_valid_block bc b ->
+  valid_chain_block bc b ->
   good_chain bc ->
   prevBlockHash b = #pb ->
   VAF (proof b) bc (txs b) ->
   good_chain (compute_chain (btExtend bt b) b) /\
-  tx_valid_chain (compute_chain (btExtend bt b) b).
+  valid_chain (compute_chain (btExtend bt b) b).
 Proof.
 move=>bc pb V Vh Ib Tb Gc Hp Hv.
 (have: bc \in all_chains bt by move: (btChain_in_bt Ib))=>InC.
@@ -1403,13 +1408,13 @@ move/eqP=>Eq; subst h; rewrite X' rcons_cons in X; case: X=> ??.
 subst x xs; split=>//.
 move: (btChain_tx_valid bt)=>Tc.
 rewrite !X' in Tb Tc; rewrite -rcons_cons.
-by apply: tx_valid_last.
+by apply: valid_chain_last.
 Qed.
 
 Lemma btExtend_mint bt b :
   let pb := last GenesisBlock (btChain bt) in
   valid bt -> validH bt -> has_init_block bt ->
-  tx_valid_block (btChain bt) b ->
+  valid_chain_block (btChain bt) b ->
   prevBlockHash b = # pb ->
   VAF (proof b) (btChain bt) (txs b) = true ->
   btChain (btExtend bt b) > btChain bt.
@@ -1417,14 +1422,14 @@ Proof.
 move=>lst V Vh Ib T mint Hv.
 have HGood: good_chain (rcons (btChain bt) b).
 - by move: (btChain_good bt); rewrite {1}/good_chain; case (btChain bt).
-have Hvalid: tx_valid_chain (rcons (btChain bt) b).
-- by move: (btChain_tx_valid bt); apply: tx_valid_last. 
+have Hvalid: valid_chain (rcons (btChain bt) b).
+- by move: (btChain_tx_valid bt); apply: valid_chain_last.
 have E: compute_chain (btExtend bt b) b = rcons (btChain bt) b.
 - apply: (@btExtend_mint_ext _ (btChain bt) b V Vh
                              Ib _ (btChain_good bt) mint Hv).
   by move/(chain_from_last V Vh Ib): (btChain_in_bt Ib).
 have HIn : rcons (btChain bt) b \in
-           filter (fun c => good_chain c && tx_valid_chain c) (all_chains (btExtend bt b)).
+           filter (fun c => good_chain c && valid_chain c) (all_chains (btExtend bt b)).
 - rewrite mem_filter HGood Hvalid/=-E/all_chains; apply/mapP.
   have V' : valid (btExtend bt b) by rewrite -btExtendV.
   exists b=>//; rewrite /all_blocks/btExtend in V'*; apply/mapP; exists (#b).
@@ -1442,7 +1447,7 @@ Qed.
 
 Definition good_bt bt :=
   forall b, b \in all_blocks bt ->
-            good_chain (compute_chain bt b) && tx_valid_chain (compute_chain bt b).
+            good_chain (compute_chain bt b) && valid_chain (compute_chain bt b).
 
 Lemma btExtend_good_chains_fold  bt bs:
   valid bt -> validH bt -> has_init_block bt ->
@@ -1507,7 +1512,7 @@ Proof.
 move=>V Vh Hib Hg N Hg'.
 have G: good_chain (compute_chain (btExtend cbt b) b).
 - by case/andP: (Hg' b (btExtend_new_block V N)).
-have T: tx_valid_chain (compute_chain (btExtend cbt b) b).
+have T: valid_chain (compute_chain (btExtend cbt b) b).
 - by case/andP: (Hg' b (btExtend_new_block V N)).
 have Eb: btExtend cbt b = (#b \\-> b \+ cbt) by rewrite /btExtend (negbTE N).
 move: (V); rewrite (btExtendV _ b)=>V'; rewrite !Eb in V' *.
@@ -1516,8 +1521,8 @@ move: (@dom_insert _ _ (#b) b cbt V')=>[ks1][ks2][Ek]Ek'.
 set get_chain := [eta compute_chain cbt] \o [eta get_block cbt].
 rewrite /good_chains{1}/all_chains/all_blocks -!seq.map_comp Ek map_cat filter_cat.
 rewrite -/get_chain.
-exists [seq c <- [seq get_chain i | i <- ks1] | good_chain c & tx_valid_chain c],
-       [seq c <- [seq get_chain i | i <- ks2] | good_chain c & tx_valid_chain c]; split=>//.
+exists [seq c <- [seq get_chain i | i <- ks1] | good_chain c & valid_chain c],
+       [seq c <- [seq get_chain i | i <- ks2] | good_chain c & valid_chain c]; split=>//.
 rewrite /all_chains/all_blocks Ek' /= -cat1s.
 have [N1 N2] : (#b \notin ks1) /\ (#b \notin ks2).
 - have U : uniq (ks1 ++ # b :: ks2) by rewrite -Ek'; apply:uniq_dom.
@@ -1531,7 +1536,7 @@ rewrite !map_cat !filter_cat ; congr (_ ++ _); clear Ek Ek'.
   have Nk: k != #b by apply/negbT/negP=>/eqP=>?; subst k; rewrite inE eqxx in N1 .
   rewrite !(btExtend_get_block V N Nk); rewrite /get_chain/=.
   set bk := (get_block cbt k).
-  have Gk: good_chain (compute_chain cbt bk) && tx_valid_chain (compute_chain cbt bk).
+  have Gk: good_chain (compute_chain cbt bk) && valid_chain (compute_chain cbt bk).
   - by apply: Hg; apply/mapP; exists k.
   case/andP: (Gk)=>Gg Gt.
   rewrite !(btExtend_compute_chain b V Vh Hib Gg) !Gk/=.
@@ -1545,7 +1550,7 @@ have Dk: k \in dom cbt by apply: (D2 k); rewrite inE eqxx.
 have Nk: k != #b by apply/negbT/negP=>/eqP=>?; subst k; rewrite inE eqxx in N2.
 rewrite !(btExtend_get_block V N Nk); rewrite /get_chain/=.
 set bk := (get_block cbt k).
-have Gk: good_chain (compute_chain cbt bk) && tx_valid_chain (compute_chain cbt bk).
+have Gk: good_chain (compute_chain cbt bk) && valid_chain (compute_chain cbt bk).
 - by apply: Hg; apply/mapP; exists k.
 case/andP: (Gk)=>Gg Gt.  
 rewrite !(btExtend_compute_chain b V Vh Hib Gg) !Gk/=.
@@ -1563,7 +1568,7 @@ Lemma btChain_alt bt:
 Proof.
 rewrite /btChain/take_better_bc/take_better_alt/good_chains.
 elim: (all_chains bt)=>//c cs/= Hi.
-by case C: (good_chain c && tx_valid_chain c)=>//=; rewrite !Hi.
+by case C: (good_chain c && valid_chain c)=>//=; rewrite !Hi.
 Qed.
 
 Lemma best_chain_in cs :
@@ -1801,7 +1806,7 @@ case: (btExtend_good_split V Vh Hib Hg Nb Hg')=>cs1[cs2][E1]E2.
 rewrite !btChain_alt in Gt *; rewrite E1 in Gt; rewrite !E2 in H1 *.
 have I: [:: GenesisBlock] \in cs1 ++ cs2.
 - rewrite -E1 mem_filter/= eqxx/=; apply/andP; split=>//; last by apply:all_chains_init.
-  exact: tx_valid_chain_init.
+  exact: valid_chain_init.
 by apply: best_element_in.
 Qed.
 
@@ -1853,7 +1858,7 @@ Lemma btExtend_within cbt bt b bs :
   valid cbt -> validH cbt -> has_init_block cbt ->
   valid bt -> validH bt -> has_init_block bt ->
   good_bt cbt -> good_bt (btExtend cbt b) ->
-  tx_valid_block (btChain bt) b ->
+  valid_chain_block (btChain bt) b ->
   btChain cbt >= btChain (btExtend bt b) ->
   prevBlockHash b = # last GenesisBlock (btChain bt) ->
   VAF (proof b) (btChain bt) (txs b) ->
@@ -1909,7 +1914,7 @@ Lemma btExtend_can_eq cbt bt b bs :
   valid cbt -> validH cbt -> has_init_block cbt ->
   valid bt -> validH bt -> has_init_block bt ->
   good_bt cbt -> good_bt (btExtend cbt b) ->
-  tx_valid_block (btChain bt) b ->
+  valid_chain_block (btChain bt) b ->
   btChain cbt >= btChain (btExtend bt b) ->
   prevBlockHash b = # last GenesisBlock (btChain bt) ->
   VAF (proof b) (btChain bt) (txs b) ->

--- a/Systems/Protocol.v
+++ b/Systems/Protocol.v
@@ -229,7 +229,7 @@ Definition procInt (st : State) (tr : InternalTransition) (ts : Timestamp) :=
       let: allowedTxs := [seq t <- pool | txValid t bc] in
       match genProof n bc allowedTxs ts with
       | Some (txs, pf) =>
-        if VAF pf ts bc txs then
+        if VAF pf bc txs then
           let: prevBlock := last GenesisBlock bc in
           let: block := mkB (hashB prevBlock) txs pf in
           if tx_valid_block bc block then

--- a/Systems/Protocol.v
+++ b/Systems/Protocol.v
@@ -232,7 +232,7 @@ Definition procInt (st : State) (tr : InternalTransition) (ts : Timestamp) :=
         if VAF pf bc txs then
           let: prevBlock := last GenesisBlock bc in
           let: block := mkB (hashB prevBlock) txs pf in
-          if tx_valid_block bc block then
+          if valid_chain_block bc block then
             let: newBt := btExtend bt block in
             let: newPool := [seq t <- pool | txValid t (btChain newBt)] in
             let: ownHashes := dom newBt ++ [seq hashT t | t <- newPool] in
@@ -261,7 +261,7 @@ Proof.
 case=> n1 p1 b1 t1 [] =>// ts; simpl.
 case hP: genProof => [[txs pf]|] //.
 case vP: (VAF _)=>//.
-case tV: (tx_valid_block _ _)=>//.
+case tV: (valid_chain_block _ _)=>//.
 Qed.
 
 Lemma procMsg_valid :
@@ -285,7 +285,7 @@ move=>s1 t ts.
 case Int: t; destruct s1; rewrite/procInt/=; first by [].
 case: genProof => [[txs pf]|]; last done.
 case: (VAF _ _ _); last done.
-case tV: (tx_valid_block _ _)=>//.
+case tV: (valid_chain_block _ _)=>//.
 by rewrite/blockTree/=; apply btExtendV.
 Qed.
 
@@ -312,7 +312,7 @@ move=>s1 t ts v vh.
 case Int: t; destruct s1; rewrite/procInt/=; first by [].
 case: genProof => [[txs pf]|]; last by [].
 case: (VAF _ _ _); last done.
-case tV: (tx_valid_block _ _)=>//.
+case tV: (valid_chain_block _ _)=>//.
 by rewrite/blockTree/=; apply btExtendH.
 Qed.
 
@@ -341,7 +341,7 @@ move=>s1 t ts v vh.
 case Int: t; destruct s1; rewrite/procInt/=; first by [].
 case: genProof => [[txs pf]|]; last by [].
 case: (VAF _ _ _); last done.
-case tV: (tx_valid_block _ _)=>//.
+case tV: (valid_chain_block _ _)=>//.
 by apply btExtendIB.
 Qed.
 
@@ -429,7 +429,7 @@ Lemma procInt_peers_uniq :
 Proof.
 move=>s1 t ts; case: s1=>n prs bt txp; rewrite /peers/procInt=>Up.
 case: t=>//; case hP: genProof => [[txs pf]|]//; case vP: (VAF _)=>//.
-case tV: (tx_valid_block _ _)=>//.
+case tV: (valid_chain_block _ _)=>//.
 Qed.
 
 Inductive local_step (s1 s2 : State) : Prop :=

--- a/Systems/Protocol.v
+++ b/Systems/Protocol.v
@@ -229,16 +229,13 @@ Definition procInt (st : State) (tr : InternalTransition) (ts : Timestamp) :=
       let: allowedTxs := [seq t <- pool | txValid t bc] in
       match genProof n bc allowedTxs ts with
       | Some (txs, pf) =>
-        if VAF pf bc txs then
-          let: prevBlock := last GenesisBlock bc in
-          let: block := mkB (hashB prevBlock) txs pf in
-          if valid_chain_block bc block then
-            let: newBt := btExtend bt block in
-            let: newPool := [seq t <- pool | txValid t (btChain newBt)] in
-            let: ownHashes := dom newBt ++ [seq hashT t | t <- newPool] in
-            pair (Node n prs newBt newPool) (emitBroadcast n prs (BlockMsg block))
-          else
-            pair st emitZero
+        let: prevBlock := last GenesisBlock bc in
+        let: b := mkB (hashB prevBlock) txs pf in
+        if valid_chain_block bc b then
+          let: newBt := btExtend bt b in
+          let: newPool := [seq t <- pool | txValid t (btChain newBt)] in
+          let: ownHashes := dom newBt ++ [seq hashT t | t <- newPool] in
+          pair (Node n prs newBt newPool) (emitBroadcast n prs (BlockMsg b))
         else
           pair st emitZero
       | None => pair st emitZero
@@ -260,7 +257,6 @@ Lemma procInt_id_constant : forall (s1 : State) (t : InternalTransition) (ts : T
 Proof.
 case=> n1 p1 b1 t1 [] =>// ts; simpl.
 case hP: genProof => [[txs pf]|] //.
-case vP: (VAF _)=>//.
 case tV: (valid_chain_block _ _)=>//.
 Qed.
 
@@ -284,7 +280,6 @@ Proof.
 move=>s1 t ts.
 case Int: t; destruct s1; rewrite/procInt/=; first by [].
 case: genProof => [[txs pf]|]; last done.
-case: (VAF _ _ _); last done.
 case tV: (valid_chain_block _ _)=>//.
 by rewrite/blockTree/=; apply btExtendV.
 Qed.
@@ -311,7 +306,6 @@ Proof.
 move=>s1 t ts v vh.
 case Int: t; destruct s1; rewrite/procInt/=; first by [].
 case: genProof => [[txs pf]|]; last by [].
-case: (VAF _ _ _); last done.
 case tV: (valid_chain_block _ _)=>//.
 by rewrite/blockTree/=; apply btExtendH.
 Qed.
@@ -340,7 +334,6 @@ Proof.
 move=>s1 t ts v vh.
 case Int: t; destruct s1; rewrite/procInt/=; first by [].
 case: genProof => [[txs pf]|]; last by [].
-case: (VAF _ _ _); last done.
 case tV: (valid_chain_block _ _)=>//.
 by apply btExtendIB.
 Qed.
@@ -428,7 +421,7 @@ Lemma procInt_peers_uniq :
     uniq (peers s1) -> uniq (peers s2).
 Proof.
 move=>s1 t ts; case: s1=>n prs bt txp; rewrite /peers/procInt=>Up.
-case: t=>//; case hP: genProof => [[txs pf]|]//; case vP: (VAF _)=>//.
+case: t=>//; case hP: genProof => [[txs pf]|]//.
 case tV: (valid_chain_block _ _)=>//.
 Qed.
 


### PR DESCRIPTION
Building on the comments in #17, here are changes that incorporate `VAF` checking into general chain validity checking (which previously only checked transaction validity). The key changes are:

- drop the timestamp argument to `VAF`
- introduce an axiom `VAF_init : VAF (proof GenesisBlock) [::] (txs GenesisBlock)`
- remove explicit call to `VAF` in `MintT`, which becomes redundant with the new definition of the function `valid_chain_block` which replaces `tx_valid_block`

I believe these changes would allow us to (roughly) instantiate Bitcoin in a straightforward way.

@dranov how do you feel about merging this right now?