### PR TITLE
add node extraction and compilation to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ opam: &OPAM
       echo \"Build triggered by ${TRAVIS_EVENT_TYPE}\"
       export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
       set -ex  # -e = exit on failure; -x = trace for debug
+      sudo apt-get update -y -q
+      DEBIAN_FRONTEND=noninteractive sudo apt-get install -y -q --no-install-recommends zlib1g-dev libgmp-dev
+      opam switch ${SWITCH} ; eval $(opam env)
       opam update -y
       opam pin add ${CONTRIB_NAME} . -y -n -k path
       opam install ${CONTRIB_NAME} -y -j ${NJOBS} --deps-only
@@ -36,16 +39,19 @@ matrix:
   # Test supported versions of Coq via OPAM
   - env:
     - COQ_IMAGE=coqorg/coq:8.9
-    - CONTRIB_NAME=coq-toychain
+    - CONTRIB_NAME=coq-toychain-node
     - NJOBS=2
+    - SWITCH=4.07.1+flambda
     <<: *OPAM
   - env:
     - COQ_IMAGE=coqorg/coq:8.10
     - CONTRIB_NAME=coq-toychain
     - NJOBS=2
+    - SWITCH=4.05.0
     <<: *OPAM
   - env:
     - COQ_IMAGE=coqorg/coq:dev
     - CONTRIB_NAME=coq-toychain
     - NJOBS=2
+    - SWITCH=4.05.0
     <<: *OPAM

--- a/README.md
+++ b/README.md
@@ -8,13 +8,22 @@ A Coq implementation of a minimalistic blockchain-based consensus protocol.
 
 ### Requirements
 
+Coq definitions and proofs:
+
 * [Coq 8.9 or later](https://coq.inria.fr)
 * [Mathematical Components](http://math-comp.github.io/math-comp/) (`ssreflect`)
 * [FCSL PCM library](https://github.com/imdea-software/fcsl-pcm)
 
+Executable node:
+
+* [OCaml 4.06.0 or later](https://ocaml.org)
+* [OCamlbuild](https://github.com/ocaml/ocamlbuild)
+* [cryptokit](https://github.com/xavierleroy/cryptokit)
+* [ipaddr](https://github.com/mirage/ocaml-ipaddr)
+
 ### Building Definitions and Proofs
 
-We recommend installing the requirements via [OPAM](https://opam.ocaml.org/doc/Install.html):
+We recommend installing the Coq requirements via [OPAM](https://opam.ocaml.org/doc/Install.html):
 ```
 opam repo add coq-released https://coq.inria.fr/opam/released
 opam install coq-mathcomp-ssreflect coq-fcsl-pcm
@@ -25,10 +34,10 @@ the libraries and check all the proofs.
 
 ### Building an Executable Node
 
-The following additional dependencies need to be installed to build
-an executable blockchain node:
+The additional OCaml dependencies for the executable node can also
+be installed via OPAM:
 ```
-opam install cryptokit ipaddr
+opam install ocamlbuild cryptokit ipaddr
 ```
 
 Then, run `make node` from the root folder. This will produce an

--- a/coq-toychain-node.opam
+++ b/coq-toychain-node.opam
@@ -9,7 +9,7 @@ synopsis: "Blockchain node extracted from verified minimalistic protocol"
 
 build: [ make "-j%{jobs}%" "node" ]
 depends: [
-  "ocaml"
+  "ocaml" {>= "4.06.0"}
   "coq" {(>= "8.9" & < "8.11~") | (= "dev")}
   "coq-mathcomp-ssreflect" {(>= "1.7" & < "1.10~") | (= "dev")}
   "coq-fcsl-pcm"


### PR DESCRIPTION
I figured out how to add the node compilation to CI, and found out that it only works with OCaml 4.06.0 or later.