### PR TITLE
Fix compilation of SeqFacts.v with mathcomp dev's branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,7 +84,9 @@ CoqMakefile.conf
 Makefile.coq.conf
 .coqdeps.d
 awk.Makefile
-
+*.vok
+*.vos
+.Makefile.coq.d
 
 # Toychain-specific
 _build

--- a/Structures/SeqFacts.v
+++ b/Structures/SeqFacts.v
@@ -2,7 +2,7 @@ From mathcomp.ssreflect
 Require Import ssreflect ssrbool ssrnat eqtype ssrfun seq path.
 Require Import Eqdep.
 From fcsl
-Require Import pred prelude ordtype pcm finmap unionmap heap.
+Require Import pred prelude ordtype pcm finmap unionmap automap heap.
 
 Set Implicit Arguments.
 
@@ -113,34 +113,14 @@ Lemma dom_ord2 {K: ordType} {T} (j k : K) (w v : T) m:
   dom (pts j w \+ (k \\-> v \+ m)) =
   if ord j k then j :: dom (k \\-> v \+ m) else k :: j :: (dom m).
 Proof.
-have A: antisymmetric ord by move=>???/andP[]H1 H2; move: (nsym H1 H2).
-case: ifP=>X V P; rewrite joinCA in V.
-- apply: (eq_sorted (@trans K) (A K))=>//=.
-  + rewrite path_min_sorted //=; apply/allP=>z.    
-    rewrite domUn inE (validR V) domPtK inE /=.
-    case/orP; first by move/eqP=>->.
-    by move/(path_ord_sorted (sorted_dom m) P).
-  apply: uniq_perm=>/=; rewrite ?dom_uniq ?[_&&true]andbC//=.
-  + by case: validUn V=>//_ _/(_ j);
-       rewrite domPtK inE eqxx=>/(_ is_true_true) ? ?; apply/andP.
-  move=>z; rewrite !inE !domUn !inE V domPtK inE /=.
-  by rewrite (validR V)/= domPtUn /= domPtK !inE (validR V) (eq_sym z k).
-apply: (eq_sorted (@trans K) (A K))=>//=.
-- rewrite P andbC/=; case/orP: (total k j) X=>///orP[]; last by move=>->.
-  move/eqP=>Z; subst j.
-  case: validUn (V)=>//_ _/(_ k); rewrite domPtK inE eqxx=>/(_ is_true_true).
-  by rewrite domUn inE domPtK inE eqxx/= andbC(validR V).
-apply: uniq_perm=>/=; rewrite ?dom_uniq ?[_&&true]andbC//=.
-- rewrite joinCA in V; case: validUn (V)=>//_ _/(_ k).
-  rewrite domPtK inE eqxx=>/(_ is_true_true)=>/negP N _.
-  apply/andP; split; last first.
-  + case: validUn (validR V)=>//_ _/(_ j).
-    by rewrite domPtK inE eqxx=>/(_ is_true_true) ? ?; apply/andP.
-  rewrite inE; apply/negP=>M; apply: N.
-  by rewrite domUn inE (validR V) domPtK inE.
-move=>z; rewrite !inE !domUn !inE V domPtK inE eq_sym/=.
-rewrite domUn inE (validR V)/= domPtK inE.
-by case: (j == z)=>//; case: (z == k).
+case: totalP=> [k_lt_j V P | /eqP-> | j_lt_k V P].
+- by rewrite joinCA !dom_ord1 ?(validX V) //= k_lt_j P.
+- by rewrite validPtUn /= domPtUn inE eqxx /= andbT andbN.
+rewrite -[pts j w]/(j \\-> w) dom_ord1 ?(validX V) //.
+rewrite path_min_sorted //; apply/allP=> z.
+rewrite domUn inE; case/andP=>[_]/orP[].
+- by rewrite domPtK inE => /eqP->.
+by move=> F; rewrite (path_ord_sorted (sorted_dom m)).
 Qed.
 
 Lemma dom_insert {K: ordType} {T} (k : K) (v : T) m :

--- a/Structures/SeqFacts.v
+++ b/Structures/SeqFacts.v
@@ -90,7 +90,7 @@ rewrite -joinCA in V; move: (Hi (validR V))=>{Hi}Hi.
 have A: antisymmetric ord by move=>???/andP[]H1 H2; move: (nsym H1 H2).  
 apply: (eq_sorted (@trans K) (A K))=>//=.
 rewrite joinCA in V.
-apply: uniq_perm_eq=>/=; rewrite ?dom_uniq ?[_&&true]andbC//=.
+apply: uniq_perm=>/=; rewrite ?dom_uniq ?[_&&true]andbC//=.
 - case: validUn V=>//_ _/(_ j).
   by rewrite domPtK inE eqxx uniq_dom=>/(_ is_true_true) ? ?; apply/andP.
 move=>z; rewrite !inE !domUn !inE V domPtK inE (eq_sym z k).
@@ -116,11 +116,11 @@ Proof.
 have A: antisymmetric ord by move=>???/andP[]H1 H2; move: (nsym H1 H2).
 case: ifP=>X V P; rewrite joinCA in V.
 - apply: (eq_sorted (@trans K) (A K))=>//=.
-  + rewrite path_min_sorted//.
-    move=>z; rewrite domUn inE (validR V) domPtK inE /=.
+  + rewrite path_min_sorted //=; apply/allP=>z.    
+    rewrite domUn inE (validR V) domPtK inE /=.
     case/orP; first by move/eqP=>->.
     by move/(path_ord_sorted (sorted_dom m) P).
-  apply: uniq_perm_eq=>/=; rewrite ?dom_uniq ?[_&&true]andbC//=.
+  apply: uniq_perm=>/=; rewrite ?dom_uniq ?[_&&true]andbC//=.
   + by case: validUn V=>//_ _/(_ j);
        rewrite domPtK inE eqxx=>/(_ is_true_true) ? ?; apply/andP.
   move=>z; rewrite !inE !domUn !inE V domPtK inE /=.
@@ -130,7 +130,7 @@ apply: (eq_sorted (@trans K) (A K))=>//=.
   move/eqP=>Z; subst j.
   case: validUn (V)=>//_ _/(_ k); rewrite domPtK inE eqxx=>/(_ is_true_true).
   by rewrite domUn inE domPtK inE eqxx/= andbC(validR V).
-apply: uniq_perm_eq=>/=; rewrite ?dom_uniq ?[_&&true]andbC//=.
+apply: uniq_perm=>/=; rewrite ?dom_uniq ?[_&&true]andbC//=.
 - rewrite joinCA in V; case: validUn (V)=>//_ _/(_ k).
   rewrite domPtK inE eqxx=>/(_ is_true_true)=>/negP N _.
   apply/andP; split; last first.

--- a/coq-toychain-node.opam
+++ b/coq-toychain-node.opam
@@ -11,7 +11,7 @@ build: [ make "-j%{jobs}%" "node" ]
 depends: [
   "ocaml" {>= "4.06.0"}
   "coq" {(>= "8.9" & < "8.11~") | (= "dev")}
-  "coq-mathcomp-ssreflect" {(>= "1.7" & < "1.10~") | (= "dev")}
+  "coq-mathcomp-ssreflect" {(>= "1.10.0") | (= "dev")}
   "coq-fcsl-pcm"
   "ocamlbuild" {build}
   "cryptokit"

--- a/coq-toychain.opam
+++ b/coq-toychain.opam
@@ -12,7 +12,7 @@ install: [ make "install" ]
 depends: [
   "ocaml"
   "coq" {(>= "8.9" & < "8.11~") | (= "dev")}
-  "coq-mathcomp-ssreflect" {(>= "1.7" & < "1.10~") | (= "dev")}
+  "coq-mathcomp-ssreflect" {(>= "1.10.0") | (= "dev")}
   "coq-fcsl-pcm"
 ]
 


### PR DESCRIPTION
Fixes #28:

- path_min_sorted hypothesis changed, and now one has to explicitly call `allP` to continue discharging the first subgoal.

- replaces uniq_perm_eq for uniq_perm to clear warnings in SeqFacts.v. Does not fix other warnings.

-  tweaked .gitignore, clearing .vok .vos files